### PR TITLE
Feature: lesson28(Part.4)

### DIFF
--- a/lesson28/src/js/changepassword-done.js
+++ b/lesson28/src/js/changepassword-done.js
@@ -1,0 +1,7 @@
+const urlParameter = Object.fromEntries(new URLSearchParams(window.location.search));
+const currentPageToken = urlParameter.token;
+const registeredToken = localStorage.getItem("passwordReissueToken");
+
+if(currentPageToken !== registeredToken) window.location.href = "./../notautherize.html";
+
+localStorage.removeItem("passwordReissueToken");

--- a/lesson28/src/js/changepassword.js
+++ b/lesson28/src/js/changepassword.js
@@ -42,7 +42,7 @@ const togglePasswordDisplay = target => {
     target.classList.toggle("is-open");
 }
 
-const changeRegisteredDataOfPassword = () => {
+const changePassword = () => {
     const newPassword = passwordOfInput.value;
     const userData = JSON.parse(localStorage.getItem("registeredData"));
     userData.password = newPassword;
@@ -50,7 +50,7 @@ const changeRegisteredDataOfPassword = () => {
 }
 
 submitButton.addEventListener("click", () => {
-    changeRegisteredDataOfPassword();
+    changePassword();
 
     const newToken = chance.apple_token();
     const newUrlParameter = `?token=${newToken}`;

--- a/lesson28/src/js/changepassword.js
+++ b/lesson28/src/js/changepassword.js
@@ -1,4 +1,6 @@
 import { checkFormValidityInBlur } from "./modules/validation";
+import { Chance } from "chance";
+const chance = new Chance();
 
 const urlParameter = Object.fromEntries(new URLSearchParams(window.location.search));
 const currentPageToken = urlParameter.token;
@@ -40,4 +42,19 @@ const togglePasswordDisplay = target => {
     target.classList.toggle("is-open");
 }
 
-submitButton.addEventListener("click", () => console.log("submitされました。この後はまだ未実装です。"))
+const changeRegisteredDataOfPassword = () => {
+    const newPassword = passwordOfInput.value;
+    const userData = JSON.parse(localStorage.getItem("registeredData"));
+    userData.password = newPassword;
+    localStorage.setItem("registeredData", JSON.stringify(userData));
+}
+
+submitButton.addEventListener("click", () => {
+    changeRegisteredDataOfPassword();
+
+    const newToken = chance.apple_token();
+    const newUrlParameter = `?token=${newToken}`;
+
+    localStorage.setItem("passwordReissueToken", newToken);
+    window.location.href = `./passworddone.html${newUrlParameter}`;
+});

--- a/lesson28/src/js/changepassword.js
+++ b/lesson28/src/js/changepassword.js
@@ -52,9 +52,9 @@ const changePassword = () => {
 submitButton.addEventListener("click", () => {
     changePassword();
 
-    const newToken = chance.apple_token();
-    const newUrlParameter = `?token=${newToken}`;
+    const token = chance.apple_token();
+    const newUrlParameter = `?token=${token}`;
 
-    localStorage.setItem("passwordReissueToken", newToken);
+    localStorage.setItem("passwordReissueToken", token);
     window.location.href = `./passworddone.html${newUrlParameter}`;
 });

--- a/lesson28/src/js/changepassword.js
+++ b/lesson28/src/js/changepassword.js
@@ -43,9 +43,9 @@ const togglePasswordDisplay = target => {
 }
 
 const changePassword = () => {
-    const newPassword = passwordOfInput.value;
+    const passwordValue = passwordOfInput.value;
     const userData = JSON.parse(localStorage.getItem("registeredData"));
-    userData.password = newPassword;
+    userData.password = passwordValue;
     localStorage.setItem("registeredData", JSON.stringify(userData));
 }
 

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -19,7 +19,7 @@ const tryToSubmit = async() => {
         localStorage.setItem("passwordReissueToken", result.token);
     } catch(rejectObj) {
         result = rejectObj;
-        submitButton.nextElementSibling.textContent = "メールアドレスが見つかりませんでした。";
+        submitButton.nextElementSibling.textContent = "一致するアカウントが見つかりませんでした";
         submitButton.disabled = true;
         return;
     } 

--- a/lesson28/src/js/modules/validation.js
+++ b/lesson28/src/js/modules/validation.js
@@ -26,6 +26,11 @@ export const validationOptions = {
         },
         errorMessage: "8文字以上の大小の英数字を交ぜたものにしてください",
     },
+    confirmPassword: {
+        isValid: () => {
+            return true;
+        },
+    },
     userId: {
         isValid: () => {
             return true;

--- a/lesson28/src/notautherize.html
+++ b/lesson28/src/notautherize.html
@@ -10,7 +10,7 @@
     <body>
         <section class="form box">
             <h1 class="title">User authentication failed.</h1>
-            <p class="register__text">ログイン権限がありません</p>
+            <p class="register__text">権限がありません</p>
             <p class="center form__anchor"><a href="./login.html" class="form__check-link">← Back to Login page</a></p>
         </section>
     </body>

--- a/lesson28/src/register/password.html
+++ b/lesson28/src/register/password.html
@@ -20,7 +20,7 @@
                 </div>
                 <div class="form__item">
                     <label for="confirmPassword">確認のためのPassword入力<span class="form__required">必須</span></label>
-                    <span class="form__eye js-eye-icon"></span><input type="password" class="form__item-input js-form-confirm-password form__eye" id="confirmPassword" name="password" required>
+                    <span class="form__eye js-eye-icon"></span><input type="password" class="form__item-input js-form-confirm-password form__eye" id="confirmPassword" name="confirmPassword" required>
                     <p class="error"></p>
                 </div>
                 <div class="form__button form__button--narrow">

--- a/lesson28/src/register/passworddone.html
+++ b/lesson28/src/register/passworddone.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <link rel="stylesheet" href="/css/reset.css">
+        <link rel="stylesheet" href="/css/style.css" >
+        <script type="module" src="../../js/changepassword-done.js"></script>
+        <title>パスワード変更完了</title>
+    </head>
+    <body>
+        <section class="box">
+            <h1 class="title">Password change is complete!</h1>
+            <p class="register__text">新しいパスワードでログインが可能です。</p>
+            <p class="center form__anchor"><a href="./../login.html" class="form__check-link">← Back to Login page</a></p>
+        </section>
+    </body>
+</html>


### PR DESCRIPTION
# [Issue No.28](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#28)

## 今回実装した仕様
- inputの値が同じでバリデーションが通ればパスワードを再発行と新たなトークンを発行して ローカルストレージに埋め込みor以前のそれを破棄、変更してください
- パスワード再設定完了ページ
register/passworddone.html?token=tagaerega <-新しいトークン で飛ばします
- 完了ページでは urlパラメータからトークンと直近で作られたトークンがローカルストレージのそれと合っていたら
「パスワード再設定が完了しました」 「ログインページへ」を表示し
- 間違っていたりトークンがなかったり直叩きでurlが間違っていたら 権限なしページに飛ばしてください
- その後、新たに作ったパスワードでログインができるようにします


## 前回までに実装した仕様
- この課題から会員登録された内容はlocalStorage内に保有され ログイン時は固定値ではなく localStorage内の値とチェックされます。 イメージしたいのはローカルストレージはここではサーバー内のテーブルとして使っています。 なので現実的ではそのような実装はないですが、ここの課題はそれで実装したいです
- 会員登録画面でsubmitした時、localStorage内の値とチェックしてメールアドレスが既に登録されていた場合はエラーを出します。
- パスワード忘れた方へ(forgetpassword.html)のページを作ってください
- 上記で作ったメールアドレス兼ユーザー名を入力するところがあります
- メールアドレスのinput値がバリデーションを通れば送信ボタンが押せます
- もしメールアドレスが登録がされていない場合は「見つかりませんでした」として会員登録に飛ばします
- この課題の実装では forgetpassword.htmlでsubmitしたらトークンを発行して(仮に482r22fafahとします)、ローカルストレージに保存。 そのあと register/password.htmlへ飛ばしてください
- forgetpassword.htmlで送信した際のリンクはregister/password.html?token=482r22fafah みたいなurlにして(このリンクが本来メール本文にあるリンクのイメージです)
- フロントはurlパラメータのtokenがすぐ前で発行した482r22fafahかどうかを確認します。 (ローカルストレージがサーバー側の役割をしているイメージ)
- もしtokenが間違っていたら notautherize.html 権限がありませんページに飛ばしてください
- urlパラメータが正しい場合にregister/password.htmlを表示します
- 表示は下記の通りで「新規パスワード入力」 「確認のためのパスワード入力」 があり、バリデーションも効きます
- inputの値が同じでバリデーションが通れば送信される

## [CodeSandBox](https://codesandbox.io/s/github/haru-programming/JavaScript-lessons/tree/feature/lesson28-4/lesson28)
Latest Commit: [af6da78](https://github.com/haru-programming/JavaScript-lessons/pull/36/commits/af6da7815a1c99b582153feb47e955c470c6b290)

## Concerns and areas to focus on
- I wrote in PR comments. Thank you for your review!
