### PR TITLE
Feature: lesson29 (Part.2)

### DIFF
--- a/lesson29/src/js/changeemail-done.js
+++ b/lesson29/src/js/changeemail-done.js
@@ -1,0 +1,8 @@
+const urlParameter = Object.fromEntries(new URLSearchParams(window.location.search));
+const currentPageToken = urlParameter.token;
+const registeredToken = localStorage.getItem("token");
+
+if(currentPageToken !== registeredToken) {
+    localStorage.removeItem("token");
+    window.location.href = "./../notautherize.html";
+}

--- a/lesson29/src/js/changeemail.js
+++ b/lesson29/src/js/changeemail.js
@@ -1,10 +1,12 @@
 import { checkFormValidityInBlur } from "./modules/validation";
+import { togglePasswordDisplay } from "./modules/togglepassword";
 
 const emailOfInput = document.querySelector(".js-form-email");
 const confirmEmailOfInput = document.querySelector(".js-form-confirm-email");
 const passwordOfInput = document.querySelector(".js-form-password");
 const formElements = [emailOfInput, confirmEmailOfInput, passwordOfInput];
 const errorOfConfirmEmail = confirmEmailOfInput.nextElementSibling;
+const eyeIcons = document.querySelectorAll(".js-eye-icon");
 const submitButton = document.querySelector(".js-submit-button");
 
 const isMatchEmailFields = () => emailOfInput.value === confirmEmailOfInput.value;
@@ -21,4 +23,19 @@ formElements.forEach(element => {
     });
 });
 
-submitButton.addEventListener("click", () => console.log("まだ未実装です"));
+eyeIcons.forEach(icon => {
+    icon.addEventListener("click", (e) => togglePasswordDisplay(e.target))
+})
+
+const changeEmail = () => {
+    const userData = JSON.parse(localStorage.getItem("registeredData"));
+    userData.email = emailOfInput.value;
+    localStorage.setItem("registeredData", JSON.stringify(userData));
+}
+
+submitButton.addEventListener("click", () => {
+    changeEmail();
+
+    const urlParameter = `?token=${localStorage.getItem("token")}`;
+    window.location.href = `./resetmaildone.html${urlParameter}`;
+});

--- a/lesson29/src/js/changeemail.js
+++ b/lesson29/src/js/changeemail.js
@@ -42,7 +42,11 @@ const changeEmail = () => {
 
 submitButton.addEventListener("click", () => {
     changeEmail();
-
-    const urlParameter = `?token=${localStorage.getItem("token")}`;
+    const token = localStorage.getItem("token");
+    if(!token) {
+        window.location.href = "./notautherize.html";
+        return;
+    }
+    const urlParameter = `?token=${token}`;
     window.location.href = `./resetmaildone.html${urlParameter}`;
 });

--- a/lesson29/src/js/changeemail.js
+++ b/lesson29/src/js/changeemail.js
@@ -10,7 +10,11 @@ const eyeIcons = document.querySelectorAll(".js-eye-icon");
 const submitButton = document.querySelector(".js-submit-button");
 
 const isMatchEmailFields = () => emailOfInput.value === confirmEmailOfInput.value;
-const checkFormValidityToEnableSubmitButton = () => submitButton.disabled = emailOfInput.value !== confirmEmailOfInput.value;
+const isMatchRegisteredPassword = () => {
+    const registeredData = JSON.parse(localStorage.getItem("registeredData"));
+    return passwordOfInput.value === registeredData.password;
+}
+const checkFormValidityToEnableSubmitButton = () => submitButton.disabled = (emailOfInput.value !== confirmEmailOfInput.value) || !isMatchRegisteredPassword();
 
 formElements.forEach(element => {
     element.classList.add("invalid");
@@ -19,7 +23,10 @@ formElements.forEach(element => {
         checkFormValidityInBlur(submitButton, element);
 
         if (emailOfInput.value && confirmEmailOfInput.value) errorOfConfirmEmail.textContent = isMatchEmailFields() ? "" : "上記のE-mailアドレスと異なります。もう一度入力してください。";
-        if (document.getElementsByClassName("invalid").length === 0) checkFormValidityToEnableSubmitButton();
+        if (document.getElementsByClassName("invalid").length === 0) {
+            passwordOfInput.nextElementSibling.textContent = isMatchRegisteredPassword() ? "" : "一致するアカウントが見つかりません";
+            checkFormValidityToEnableSubmitButton();
+        };
     });
 });
 

--- a/lesson29/src/js/changeemail.js
+++ b/lesson29/src/js/changeemail.js
@@ -14,7 +14,7 @@ const isMatchRegisteredPassword = () => {
     const registeredData = JSON.parse(localStorage.getItem("registeredData"));
     return passwordOfInput.value === registeredData.password;
 }
-const checkFormValidityToEnableSubmitButton = () => submitButton.disabled = (emailOfInput.value !== confirmEmailOfInput.value) || !isMatchRegisteredPassword();
+const checkFormValidityToEnableSubmitButton = () => submitButton.disabled = (emailOfInput.value !== confirmEmailOfInput.value);
 
 formElements.forEach(element => {
     element.classList.add("invalid");
@@ -24,7 +24,6 @@ formElements.forEach(element => {
 
         if (emailOfInput.value && confirmEmailOfInput.value) errorOfConfirmEmail.textContent = isMatchEmailFields() ? "" : "上記のE-mailアドレスと異なります。もう一度入力してください。";
         if (document.getElementsByClassName("invalid").length === 0) {
-            passwordOfInput.nextElementSibling.textContent = isMatchRegisteredPassword() ? "" : "一致するアカウントが見つかりません";
             checkFormValidityToEnableSubmitButton();
         };
     });
@@ -41,6 +40,12 @@ const changeEmail = () => {
 }
 
 submitButton.addEventListener("click", () => {
+    if(!isMatchRegisteredPassword()){
+        passwordOfInput.nextElementSibling.textContent = "パスワードが一致しません";
+        submitButton.disabled = true;
+        return;
+    }
+
     changeEmail();
     const token = localStorage.getItem("token");
     if(!token) {

--- a/lesson29/src/js/changepassword.js
+++ b/lesson29/src/js/changepassword.js
@@ -1,4 +1,5 @@
 import { checkFormValidityInBlur } from "./modules/validation";
+import { togglePasswordDisplay } from "./modules/togglepassword";
 import { Chance } from "chance";
 const chance = new Chance();
 
@@ -35,12 +36,6 @@ formElements.forEach(element => {
 eyeIcons.forEach(icon => {
     icon.addEventListener("click", (e) => togglePasswordDisplay(e.target))
 })
-
-const togglePasswordDisplay = target => {
-    const selectedInput = target.nextElementSibling;
-    selectedInput.type = selectedInput.type === "password" ? "text" : "password";
-    target.classList.toggle("is-open");
-}
 
 const changePassword = () => {
     const passwordValue = passwordOfInput.value;

--- a/lesson29/src/js/login.js
+++ b/lesson29/src/js/login.js
@@ -1,10 +1,12 @@
 import { checkFormValidityInBlur, checkFormValidityToEnableSubmitButton } from "./modules/validation";
+import { togglePasswordDisplay } from "./modules/togglepassword";
 import { Chance } from "chance";
 const chance = new Chance();
 
 const userIdOfInput = document.querySelector(".js-form-userid");
 const passwordOfInput = document.querySelector(".js-form-password");
 const formElements = [userIdOfInput,passwordOfInput];
+const eyeIcons = document.querySelectorAll(".js-eye-icon");
 const submitButton = document.querySelector(".js-submit-button");
 const invalidItems = document.getElementsByClassName("invalid");
 
@@ -16,6 +18,13 @@ formElements.forEach(element => {
         checkFormValidityToEnableSubmitButton(submitButton,invalidItems);
     });
 });
+
+eyeIcons.forEach(icon => {
+    icon.addEventListener("click", (e) => {
+        e.preventDefault;
+        togglePasswordDisplay(e.target);
+    })
+})
 
 const tryToLogin = async() => {
     let result;

--- a/lesson29/src/js/modules/togglepassword.js
+++ b/lesson29/src/js/modules/togglepassword.js
@@ -1,0 +1,5 @@
+export const togglePasswordDisplay = target => {
+    const selectedInput = target.nextElementSibling;
+    selectedInput.type = selectedInput.type === "password" ? "text" : "password";
+    target.classList.toggle("is-open");
+}

--- a/lesson29/src/js/modules/togglepassword.js
+++ b/lesson29/src/js/modules/togglepassword.js
@@ -1,5 +1,12 @@
 export const togglePasswordDisplay = target => {
     const selectedInput = target.nextElementSibling;
-    selectedInput.type = selectedInput.type === "password" ? "text" : "password";
+
+    if (selectedInput.type === "password"){
+        selectedInput.type = "text";
+        target.setAttribute("aria-label", "パスワードを非表示にします");
+    } else {
+        selectedInput.type = "password";
+        target.setAttribute("aria-label", "パスワードを表示します");
+    }
     target.classList.toggle("is-open");
 }

--- a/lesson29/src/js/register.js
+++ b/lesson29/src/js/register.js
@@ -1,4 +1,5 @@
 import { showErrorMessage,checkFormValidityInBlur, checkFormValidityToEnableSubmitButton } from "./modules/validation";
+import { togglePasswordDisplay } from "./modules/togglepassword";
 
 const bodyElement = document.querySelector("body");
 const checkboxLink = document.getElementById("js-checkbox-link");
@@ -51,6 +52,7 @@ const nameOfInput = document.querySelector(".js-form-name");
 const emailOfInput = document.querySelector(".js-form-email");
 const passwordOfInput = document.querySelector(".js-form-password");
 const formElements = [nameOfInput, emailOfInput, passwordOfInput];
+const eyeIcons = document.querySelectorAll(".js-eye-icon");
 
 formElements.forEach(element => {
     element.classList.add("invalid");
@@ -60,6 +62,10 @@ formElements.forEach(element => {
         checkFormValidityToEnableSubmitButton(submitButton,invalidItems);
     });
 });
+
+eyeIcons.forEach(icon => {
+    icon.addEventListener("click", (e) => togglePasswordDisplay(e.target))
+})
 
 checkbox.addEventListener("input", () => {
     submitButton.disabled = !checkbox.checked;

--- a/lesson29/src/login.html
+++ b/lesson29/src/login.html
@@ -25,8 +25,8 @@
                 </div>
                 <div class="form__item">
                     <label for="password">Password</label>
-                    <input type="password" class="form__item-input js-form-password" id="password" name="password" required>
-                    <p class="error"></p>
+                    <button class="form__eye js-eye-icon" aria-label="パスワードが表示されます" type="button"></button><input type="password" class="form__item-input js-form-password" id="password" name="password" aria-describedby="confirm-password-constraints" required>
+                    <p class="error" id="confirm-password-constraints"></p>
                 </div>
                 <p class="form__text"><a class="form__check-link" href="./forgotpassword.html">パスワードをお忘れの方はこちら</a></p>
                 <div class="form__button">

--- a/lesson29/src/register.html
+++ b/lesson29/src/register.html
@@ -29,8 +29,8 @@
                 </div>
                 <div class="form__item">
                     <label for="password">Password<span class="form__notion"> ( 8文字以上の大小英数字 )</span><span class="form__required">必須</span></label>
-                    <input type="password" class="form__item-input js-form-password" id="password" name="password" required>
-                    <p id="js-password-error" class="error"></p>
+                    <button class="form__eye js-eye-icon" aria-label="パスワードが表示されます" type="button"></button><input type="password" class="form__item-input js-form-password" id="password" name="password" aria-describedby="confirm-password-constraints" required>
+                    <p id="confirm-password-constraints" class="error"></p>
                 </div>
                 <div class="form__check" id="js-checkbox-aria">
                     <input type="checkbox" name="answer" title="answer" value="利用規約に同意しました" id="js-checkbox" class="invalid" disabled>

--- a/lesson29/src/register/password.html
+++ b/lesson29/src/register/password.html
@@ -15,13 +15,13 @@
             <div class="form__inner">
                 <div class="form__item">
                     <label for="password">新規Password入力<span class="form__notion"> ( 8文字以上の大小英数字 )</span><span class="form__required">必須</span></label>
-                    <span class="form__eye js-eye-icon"></span><input type="password" class="form__item-input js-form-password" id="password" name="password" required>
-                    <p class="error"></p>
+                    <button class="form__eye js-eye-icon" aria-label="パスワードが表示されます"></button><input type="password" class="form__item-input js-form-password" id="password" name="password" aria-describedby="password-constraints" required>
+                    <p class="error" id="password-constraints"></p>
                 </div>
                 <div class="form__item">
                     <label for="confirmPassword">確認のためのPassword入力<span class="form__required">必須</span></label>
-                    <span class="form__eye js-eye-icon"></span><input type="password" class="form__item-input js-form-confirm-password form__eye" id="confirmPassword" name="confirmPassword" required>
-                    <p class="error"></p>
+                    <button class="form__eye js-eye-icon" aria-label="パスワードが表示されます" type="button"></button><input type="password" class="form__item-input js-form-confirm-password form__eye" id="confirmPassword" name="confirmPassword" aria-describedby="confirm-password-constraints" required>
+                    <p class="error" id="confirm-password-constraints"></p>
                 </div>
                 <div class="form__button form__button--narrow">
                     <input type="button" name="submitButton" class="js-submit-button" value="Submit" disabled>

--- a/lesson29/src/resetingemail.html
+++ b/lesson29/src/resetingemail.html
@@ -53,7 +53,7 @@
                         </div>
                         <div class="form__item">
                             <label for="password">登録済みPassword入力<span class="form__notion"> ( 本人確認のため )</span><span class="form__required">必須</span></label>
-                            <input type="password" class="form__item-input js-form-password" id="password" name="password" required>
+                            <span class="form__eye js-eye-icon"></span><input type="password" class="form__item-input js-form-password" id="password" name="password" required>
                             <p class="error"></p>
                         </div>
                         <div class="form__button form__button--narrow">

--- a/lesson29/src/resetingemail.html
+++ b/lesson29/src/resetingemail.html
@@ -53,8 +53,8 @@
                         </div>
                         <div class="form__item">
                             <label for="password">登録済みPassword入力<span class="form__notion"> ( 本人確認のため )</span><span class="form__required">必須</span></label>
-                            <span class="form__eye js-eye-icon"></span><input type="password" class="form__item-input js-form-password" id="password" name="password" required>
-                            <p class="error"></p>
+                            <button class="form__eye js-eye-icon" aria-label="パスワードが表示されます" type="button"></button><input type="password" class="form__item-input js-form-password" id="password" name="password" aria-describedby="password-constraints" required>
+                            <p class="error" id="password-constraints"></p>
                         </div>
                         <div class="form__button form__button--narrow">
                             <input type="button" name="submitButton" class="js-submit-button" value="Submit" disabled>

--- a/lesson29/src/resetmaildone.html
+++ b/lesson29/src/resetmaildone.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <link href="/css/style.css" rel="stylesheet">
+        <script type="module" src="./js/changeemail-done.js"></script>
+        <title>Email address change completed</title>
+    </head>
+    <body>
+        <section class="form box">
+            <h1 class="title">Email address changed!</h1>
+            <p class="register__text">メールアドレスが再登録されました。</p>
+            <p class="center form__anchor"><a href="./" class="form__check-link">コンテンツページへ戻る</a></p>
+        </section>
+    </body>
+</html>


### PR DESCRIPTION
# [Issue No.29](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#29)
- メールアドレス変更画面を作ってください

## 前回までに実装済みの仕様
- メールアドレス変更画面を作ってください
- ログイン中の画面から遷移できるようにします コンテンツページのどこかにメールアドレス変更 のリンクを作ります
- リンク先はresetingemail.htmlで
- 新しいメールアドレス入力inputと確認のためのメールアドレス入力inputがあります
- パスワード入力inputもあります
- 送信ボタンがあります
- このページを訪れた時ログイン判定してください。トークンがあればメールアドレス変更ページが表示されます これは直叩き防止のためです。(コンテンツページと一緒)
- 各種input バリデーション → バリデーションが通れば送信ボタンが押せる

## 今回実装した仕様
- この画面では簡単にフロントだけで実装します 2つの値とパスワードを検証して問題なければ新しいメールアドレスで ローカルストレージに埋め込んでください
- その後 現在ローカルストレージに入っているトークンをurlパラメータに付与してresetmaildone.html?token=fafafaページに遷移
- メールアドレスが再登録されました と表示してください
- ここでも描画時に、直叩き防止のために現在ローカルストレージに入っているトークンとurlパラメータがあっているか確認してください
- その後、新しいメールアドレスでログインができたらok
- 古いメルアドは使えないことを確認してください

## 未実装の仕様
- パスワード再設定のページと同様のイメージです。ログイン中の画面に作ります(これは余力があれば作ってください)

## [CodeSandBox](https://codesandbox.io/s/github/haru-programming/JavaScript-lessons/tree/feature/lesson29-2/lesson29?file=/src/js/changeemail.js)<br>

## Concerns and areas to focus on
- Detailed comments are in PR. Thank you for your review!
