### PR TITLE
Feature: lesson30 (Part.3)

### DIFF
--- a/lesson30/src/js/drawer-menu.js
+++ b/lesson30/src/js/drawer-menu.js
@@ -9,18 +9,32 @@ const toggleInertAttribute = (targets, boolean) => {
         target.inert = boolean;
     })
 }
+const openMenu = (button, menu) => {
+    body.classList.add("is-drawer-active");
+    menu.classList.add("is-open");
+    menu.setAttribute("aria-hidden", false);
+    button.setAttribute("aria-expanded", true);
+    toggleInertAttribute(focusControlTargets,true);
+}
+
+const closeMenu = (button, menu) => {
+    body.classList.remove("is-drawer-active");
+    menu.classList.remove("is-open");
+    menu.setAttribute("aria-hidden", true);
+    button.setAttribute("aria-expanded", false);
+    toggleInertAttribute(focusControlTargets,false);
+}
 
 hamburgerButton.addEventListener("click", (e) => {
-    body.classList.toggle("is-drawer-active");
-    drawerMenu.classList.toggle("is-open");
-
-    if (isOpen(e.target)){
-        e.target.setAttribute("aria-expanded", false);
-        drawerMenu.setAttribute("aria-hidden", true);
-        toggleInertAttribute(focusControlTargets,false);
+    if(isOpen(e.target)){
+        closeMenu(e.target, drawerMenu);
     } else {
-        e.target.setAttribute("aria-expanded", true);
-        drawerMenu.setAttribute("aria-hidden", false);
-        toggleInertAttribute(focusControlTargets,true);
+        openMenu(e.target, drawerMenu);
     }
 })
+
+document.addEventListener("click", (e) => {
+    if (e.target.classList.contains("is-drawer-active")) {
+        closeMenu(hamburgerButton, drawerMenu);
+    }
+});


### PR DESCRIPTION
# [Issue No.30](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#30)
- 自作ドロワーメニューを作ってください
## [CodeSandBox](https://codesandbox.io/s/github/haru-programming/JavaScript-lessons/tree/feature/lesson30-3/lesson30?file=/src/js/drawer-menu.js)<br>

## 今回の実装
- メニュー以外の部分をクリックすると、メニューが閉じる（仕様外）
- メニューの開閉をそれぞれ関数化

## 前回実装した仕様
- 左上にハンバーガーボタンがあり それを押すと 横からシュッと画面の半分より短めなコンテンツがててくる
- コンテンツ以外はopacityで下のコンテンツが見える状態
- 開いている間は全体は固定, 画面のどこをフリックしてもぐわんぐわんしない
- 会員登録とログインをメニューへ入れること

## 未実装
- SPも考慮したものにする
- 何かアニメーションを入れてもいいです(任意)
- コンテンツ内は要素が多い場合スクロールできる
