### PR TITLE
Lesson30-4 Add Esc key to close the menu and link transition

### DIFF
--- a/lesson30/src/js/drawer-menu.js
+++ b/lesson30/src/js/drawer-menu.js
@@ -38,3 +38,7 @@ document.addEventListener("click", (e) => {
         closeMenu(hamburgerButton, drawerMenu);
     }
 });
+
+document.addEventListener("keydown", (e) => {
+    if(e.key === "Escape") closeMenu(hamburgerButton, drawerMenu);
+})

--- a/lesson30/src/login.html
+++ b/lesson30/src/login.html
@@ -19,8 +19,8 @@
                 <nav class="header__nav" id="global-nav" data-name="drawer-menu" aria-hidden="true">
                     <div class="header__nav-inner">
                         <ul class="header__nav-list">
-                            <li class="header__nav-item"><a href="#" class="header__link" tabindex="2">Sign up</a></li>
-                            <li class="header__nav-item"><a href="#" class="header__link" tabindex="3">Login</a></li>
+                            <li class="header__nav-item"><a href="./register.html" class="header__link" tabindex="2">Sign up</a></li>
+                            <li class="header__nav-item"><a href="./login.html" class="header__link" tabindex="3">Login</a></li>
                         </ul>
                     </div>
                 </nav>

--- a/lesson30/src/register.html
+++ b/lesson30/src/register.html
@@ -7,9 +7,29 @@
         <link rel="stylesheet" href="./css/reset.css">
         <link rel="stylesheet" href="./css/style.css">
         <script type="module" src="./js/register.js"></script>
+        <script type="module" src="./js/drawer-menu.js"></script>
         <title>Sign Up</title>
     </head>
     <body>
+        <header class="header" id="js-header">
+            <div class="header__inner">
+                <h1 class="title title--top title--center" id="js-title"><a href="./" class="header__link">haru news</a></h1>
+                <nav class="header__nav" id="global-nav" data-name="drawer-menu" aria-hidden="true">
+                    <div class="header__nav-inner">
+                        <ul class="header__nav-list">
+                            <li class="header__nav-item"><a href="./register.html" class="header__link" tabindex="2">Sign up</a></li>
+                            <li class="header__nav-item"><a href="./login.html" class="header__link" tabindex="3">Login</a></li>
+                        </ul>
+                    </div>
+                </nav>
+                <button type="button" id="js-hamburger-button" class="header__hamburger" aria-controls="global-nav" aria-expanded="false" tabindex="1">
+                    <span class="header__hamburger-bar">
+                        <span class="header__hamburger-text">メニューを開閉する</span>
+                    </span>
+                </button>
+            </div>
+        </header>
+
         <form class="form box" id="js-form">
             <div class="form__title">
                 <a class="form__title-link" href="./">Login</a>


### PR DESCRIPTION
# [Issue No.30](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#30)
- 自作ドロワーメニューを作ってください
## [CodeSandBox](https://codesandbox.io/s/github/haru-programming/JavaScript-lessons/tree/feature/lesson30-4/lesson30?file=/src/js/drawer-menu.js)<br>

## 今回の実装
- ドロワーメニュー内のリンクを機能させる
- Escapeキーを押すとメニューが閉じる(仕様外)
- ドロワーメニューを会員登録画面(register.html)にも追加

## 前回実装した仕様
- 左上にハンバーガーボタンがあり それを押すと 横からシュッと画面の半分より短めなコンテンツがててくる
- コンテンツ以外はopacityで下のコンテンツが見える状態
- 開いている間は全体は固定, 画面のどこをフリックしてもぐわんぐわんしない
- 会員登録とログインをメニューへ入れること
- Tabキーでメニューの開閉ができる (仕様外)
- メニュー以外の部分をクリックすると、メニューが閉じる（仕様外）

## 未実装
- SPも考慮したものにする
- コンテンツ内は要素が多い場合スクロールできる