### PR TITLE
Lesson32-1: Create news list page and fetch news list data from json API

### DIFF
--- a/lesson32/src/archive-news.html
+++ b/lesson32/src/archive-news.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <link rel="stylesheet" href="./css/reset.css" type="text/css">
+        <link rel="stylesheet" href="./css/style.css" type="text/css">
+    <!-- <script>if (!localStorage.getItem("token")) window.location.href = "./login.html";</script> -->
+    <script src="./js/contents/main.js" defer></script>
+    <script type="module" src="./js/archive-news.js"></script>
+        <title>ニュース一覧</title>
+    </head>
+    <body>
+        <header class="header">
+            <div class="header__inner">
+                <h1 class="title title--top"><a href="./" class="header__link">haru news</a></h1>
+                <button class="header__button" id="js-user-menu-button" type="button"><img src="./img/img-user.png" alt="ユーザー管理画面" width="60" height="60" decoding="async"></button>
+            </div>
+            <div class="user-menu" id="js-user-menu" role="dialog">
+                <button class="user-menu__icon" id="js-close-icon" aria-label="Close">&times;</button>
+                <span class="user-menu__img"><img src="./img/img-user.png" alt="ユーザー画像"></span>
+                <p class="user-menu__name" id="js-username"></p>
+                <p class="user-menu__email" id="js-email"></p>
+                <ul class="user-menu__list">
+                    <li class="user-menu__item"><a href="./reset-email.html" class="user-menu__link">メールアドレス変更</a></li>
+                    <li class="user-menu__item"><a href="./reset-password.html" class="user-menu__link">パスワード変更</a></li>
+                </ul>
+                <button class="user-menu__button" id="js-logout-button" type="button">Logout</button>
+            </div>
+        </header>
+        <section class="news">
+            <div class="news__inner">
+                <div class="news__head">
+                    <h2 class="title title--sub">ニュース記事一覧</h2>
+                    <div class="news__select">
+                        <label for="select-category">カテゴリー検索</label>
+                        <select name="select" class="news__pulldown" id="select-category">
+                            <option value="all">すべて</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="news__body" id="js-news-body"></div>
+            </div>
+        </section>
+    </body>
+</html>

--- a/lesson32/src/archive-news.html
+++ b/lesson32/src/archive-news.html
@@ -6,9 +6,8 @@
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <link rel="stylesheet" href="./css/reset.css" type="text/css">
         <link rel="stylesheet" href="./css/style.css" type="text/css">
-    <!-- <script>if (!localStorage.getItem("token")) window.location.href = "./login.html";</script> -->
-    <script src="./js/contents/main.js" defer></script>
-    <script type="module" src="./js/archive-news.js"></script>
+        <script src="./js/contents/main.js" defer></script>
+        <script type="module" src="./js/archive-news.js"></script>
         <title>ニュース一覧</title>
     </head>
     <body>

--- a/lesson32/src/css/style.css
+++ b/lesson32/src/css/style.css
@@ -469,7 +469,8 @@ body.is-drawer-active:after{
 } 
 
 .news__select{
-    display: flex;flex-direction: column;
+    display: flex;
+    flex-direction: column;
     width: fit-content;
     margin: 30px 0 0 auto;
 }

--- a/lesson32/src/css/style.css
+++ b/lesson32/src/css/style.css
@@ -419,6 +419,42 @@ body.is-drawer-active:after{
 }
 
 /* -----------------------------------------------------------------
+// news
+// ---------------------------------------------------------------*/
+.news{
+    padding: 0 40px;
+    margin-top: 80px
+}
+
+.news__inner{
+    width: 100%;
+    max-width: 1000px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.news__head{
+    padding: 50px 30px 20px;
+    background-color: #cccccc60;
+}
+
+.news__head .title{
+    margin: 0;
+} 
+
+.news__select{
+    display: flex;flex-direction: column;
+    width: fit-content;
+    margin: 30px 0 0 auto;
+}
+
+.news__body{
+    background-color: #fff;
+    padding: 40px;
+}
+
+
+/* -----------------------------------------------------------------
 // form
 // ---------------------------------------------------------------*/
 
@@ -1014,6 +1050,35 @@ body.is-drawer-active:after{
 
     .title.title--green{
         font-size: 5.2vw;
+    }
+
+    .news{
+        padding: 0 5vw;
+        margin-top: 10vw;
+    }
+    
+    .news__inner{
+        width: 100%;
+        max-width: auto;
+    }
+    
+    .news__head{
+        padding: 9vw 4vw 6vw 4vw;
+        border-radius: 2vw 2vw 0 0;
+    }
+    
+    .news__select{
+        margin: 3vw 0 0 auto;
+    }
+
+    .news__select label{
+        font-size: 2.6vw;
+    }
+    
+    .news__body{
+        background-color: #fff;
+        padding: 4vw;
+        border-radius: 0 0 2vw 2vw;
     }
 
     .tab {

--- a/lesson32/src/css/style.css
+++ b/lesson32/src/css/style.css
@@ -60,6 +60,12 @@ body.is-drawer-active:after{
     text-align: center;
 }
 
+.inner{
+    max-width: 580px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 .title{
     text-align: center;
     font-size: 24px;
@@ -106,6 +112,25 @@ body.is-drawer-active:after{
     padding: 40px 30px;
     max-width: 370px;
 }
+
+.link{
+    display: block;
+    color: #333;
+    text-decoration-color: currentColor;
+    text-underline-offset: 6px;
+    transition: opacity 0.3s ease-in-out, text-decoration-color 0.3s ease-in-out;
+}
+
+.link:hover{
+    opacity: 0.6;
+    text-decoration-color: transparent;
+}
+
+.link--top{
+    margin-top: 40px;
+    text-align: right;
+}
+
 
 /* -----------------------------------------------------------------
 // header
@@ -436,6 +461,7 @@ body.is-drawer-active:after{
 .news__head{
     padding: 50px 30px 20px;
     background-color: #cccccc60;
+    border-radius: 8px 8px 0 0;
 }
 
 .news__head .title{
@@ -819,16 +845,12 @@ body.is-drawer-active:after{
 // tab
 // ---------------------------------------------------------------*/
 
-.tab-contents{
-    margin-top: 120px;
-}
-
 .tab {
     width: 579px;
     border: 1px solid #ccc;
     border-top: none;
     border-radius: 2px;
-    margin: 60px auto 0 auto;
+    margin: 20px auto 0 auto;
 }
 
 .tab__error{
@@ -1052,6 +1074,14 @@ body.is-drawer-active:after{
         font-size: 5.2vw;
     }
 
+    .link{
+        font-size: 2.8vw;
+    }
+
+    .link--top{
+        margin-top: 7vw;
+    }
+
     .news{
         padding: 0 5vw;
         margin-top: 10vw;
@@ -1083,7 +1113,7 @@ body.is-drawer-active:after{
 
     .tab {
         max-width: 88vw;
-        margin-top: 10vw;
+        margin-top: 5vw;
     }
     
     .tab__nav-button {

--- a/lesson32/src/index.html
+++ b/lesson32/src/index.html
@@ -44,7 +44,10 @@
             </div>
         </div>
         
-        <h2 class="title title--sub">＼ Today's News ／</h2>
-        <ul class="tab__nav-list" id="js-tabNav"></ul>
+        <section class="inner">
+            <h2 class="title title--sub">＼ Today's News ／</h2>
+            <a href="./archive-news.html" class="link link--top">→ ニュース記事一覧へ移動</a>
+            <ul class="tab__nav-list" id="js-tabNav"></ul>
+        </section>
     </body>
 </html>

--- a/lesson32/src/js/archive-news.js
+++ b/lesson32/src/js/archive-news.js
@@ -1,0 +1,61 @@
+const newsContent = document.getElementById("js-news-body");
+
+const url = "https://mocki.io/v1/6cb2582d-1e91-4777-a963-729425ae5962";
+// const url = "https://mocki.io/v1/8cc57c74-d671-48ac-b59f-d3dfb73ec8c1"; //No data
+// const url = "https://httpstat.us/503"; // 503 error
+// const url = "https://mocki.io/v1/fafafafa"; // Failed to fetch
+
+
+const addLoading = (target) => {
+    const img = document.createElement("img");
+    img.src = "./img/loading-circle.gif";
+    img.id = "js-loading";
+    target.appendChild(img);
+}
+
+const removeLoading = () => document.getElementById("js-loading").remove();
+
+const displayInfo = (target, error) => {
+    const p = document.createElement("p");
+    p.textContent = error;
+    target.appendChild(p);
+};
+
+const displayErrorStatus = (target, response) => {
+    const p = document.createElement("p");
+    p.textContent = `${response.status}:${response.statusText}`;
+    target.appendChild(p);
+};
+
+const fetchData = async(api) => {
+    addLoading(newsContent);
+    try {
+        const response = await fetch(api);
+
+        if (response.ok) {
+            return await response.json();
+        } else {
+            console.error(`${response.status}:${response.statusText}`);
+            displayErrorStatus(newsContent, response);
+        }
+        
+    } catch (error) {
+        displayInfo(newsContent, error);
+    } finally {
+        removeLoading();
+    }
+};
+
+const fetchListData = async() => {
+    const data = await fetchData(url);
+
+    if (!data) return;
+    if (!data.length) {
+        displayInfo(newsContent, "no data");
+    } else {
+        // TODO ニュース記事の一覧を作成する（一旦fetchできているかの確認のためconsole表示しました。）
+        console.log(data);
+    }
+};
+
+fetchListData();

--- a/lesson32/src/news.json
+++ b/lesson32/src/news.json
@@ -1,0 +1,197 @@
+[
+    {
+        "id": "81f55329-9212-41b6-a71b-c7c02bcdee54",
+        "category": "news",
+        "display": true,
+        "img": "./img/img-news.png",
+        "articles": [
+            {
+                "id": "89e779dd-a096-4ef4-b810-9a8f0a80ef18",
+                "date": "2022-03-02",
+                "title": "宇宙からのお土産？隕石に刻まれたエイリアンの伝言",
+                "img": "./img/img-news01.jpg",
+                "comments": [
+                    {
+                        "id": "6b999dda-f0cb-443a-abe1-9158cc537ad9",
+                        "name": "takeda",
+                        "text": "It's so hard, my head is going to explode."
+                    },
+                    {
+                        "id": "6b999dda-f0cb-443a-abe1-9158cc537ad8",
+                        "name": "yamada",
+                        "text": "It's so hard, my head is going to explode."
+                    },
+                    {
+                        "id": "6b999dda-f0cb-443a-abe1-9158cc537ad7",
+                        "name": "takahashi",
+                        "text": "It's so hard, my head is going to explode."
+                    }
+                ]
+            },
+            {
+                "id": "89e779dd-a096-4ef4-b810-9a8f0a80ef19",
+                "date": "2022-03-08",
+                "title": "世界初！ペンギン専用の交通信号機が登場",
+                "img": "./img/img-news02.jpg",
+                "comments": []
+            },
+            {
+                "id": "89e779dd-a096-4ef4-b810-9a8f0a80ef20",
+                "date": "2021-12-30",
+                "title": "ロボットが人間を模倣：休暇を楽しむAIが登場",
+                "img": "./img/img-news03.jpg",
+                "comments": []
+            },
+            {
+                "id": "89e779dd-a096-4ef4-b810-9a8f0a80ef21",
+                "date": "2022-1-3",
+                "title": "インビジブル・アート：透明な絵画がオークションで高値",
+                "img": "./img/img-news04.jpg",
+                "comments": []
+            }
+        ]
+    },
+    {
+        "id": "91f55329-9212-41b6-a71b-c7c02bcdee54",
+        "category": "economy",
+        "display": false,
+        "img": "./img/img-economy.png",
+        "articles": [
+            {
+                "id": "99e779dd-a096-4ef4-b810-9a8f0a80ef18",
+                "date": "2022-03-08",
+                "title": "宇宙人通貨！火星の仮想通貨ブームに地球が熱狂",
+                "img": "./img/img-economy01.png",
+                "comments": []
+            },
+            {
+                "id": "99e779dd-a096-4ef4-b810-9a8f0a80ef19",
+                "date": "2021-11-30",
+                "title": "お金が生える木、ついに発見！経済界に革命が訪れる？",
+                "img": "./img/img-economy02.png",
+                "comments": [
+                {
+                    "id": "5a999dda-f0cb-443a-abe1-9158cc537ad9",
+                    "name": "takeda",
+                    "text": "It's so hard, my head is going to explode."
+                },
+                {
+                    "id": "5a999dda-f0cb-443a-abe1-9158cc537ad8",
+                    "name": "yamada",
+                    "text": "It's so hard, my head is going to explode."
+                }
+                ]
+            },
+            {
+                "id": "99e779dd-a096-4ef4-b810-9a8f0a80ef20",
+                "date": "2021-12-30",
+                "title": "AIが決める給与！ロボットが人間の仕事を評価",
+                "img": "./img/img-economy03.png",
+                "comments": []
+            },
+            {
+                "id": "99e779dd-a096-4ef4-b810-9a8f0a80ef21",
+                "date": "2022-1-3",
+                "title": "未来予測が新ビジネス！タイムトラベラー投資家が急増",
+                "img": "./img/img-economy04.png",
+                "comments": []
+            }
+        ]
+    },
+    {
+        "id": "61f55329-9212-41b6-a71b-c7c02bcdee54",
+        "category": "entertainment",
+        "display": false,
+        "img": "./img/img-entertainment.png",
+        "articles": [
+            {
+                "id": "69e779dd-a096-4ef4-b810-9a8f0a80ef18",
+                "date": "2022-03-08",
+                "title": "ゾンビ映画の撮影中、本物のゾンビが現れる！",
+                "img": "./img/img-entertainment01.png",
+                "comments": []
+            },
+            {
+                "id": "69e779dd-a096-4ef4-b810-9a8f0a80ef19",
+                "date": "2021-11-30",
+                "title": "世界最速のピザ配達！ジェットパックで空を飛ぶピザ屋が大ヒット",
+                "img": "./img/img-entertainment02.png",
+                "comments": []
+            },
+            {
+                "id": "69e779dd-a096-4ef4-b810-9a8f0a80ef20",
+                "date": "2021-12-30",
+                "title": "AIが映画監督デビュー！機械が描く感動のヒューマンドラマ",
+                "img": "./img/img-entertainment03.png",
+                "comments": [
+                    {
+                        "id": "6b999dda-f0cb-443a-abe1-9158cc537ad9",
+                        "name": "takeda",
+                        "text": "It's so hard, my head is going to explode."
+                    }
+                ]
+            },
+            {
+                "id": "69e779dd-a096-4ef4-b810-9a8f0a80ef21",
+                "date": "2022-1-3",
+                "title": "ハリウッドスターが実際のスパイに！映画の役柄が現実に",
+                "img": "./img/img-entertainment04.png",
+                "comments": []
+            }
+        ]
+    },
+    {
+        "id": "21f55329-9212-41b6-a71b-c7c02bcdee54",
+        "category": "domestic",
+        "display": false,
+        "img": "./img/img-domestic.png",
+        "articles": [
+            {
+                "id": "29e779dd-a096-4ef4-b810-9a8f0a80ef18",
+                "date": "2022-03-08",
+                "title": "渋谷のハチ公像が突然動き出す！驚きのプロジェクションマッピング技術披露",
+                "img": "./img/img-domestic01.png",
+                "comments": []
+            },
+            {
+                "id": "29e779dd-a096-4ef4-b810-9a8f0a80ef19",
+                "date": "2021-11-30",
+                "title": "富士山頂で寿司レストラン開店！絶景を楽しみながら握りを堪能",
+                "img": "./img/img-domestic02.png",
+                "comments": []
+            },
+            {
+                "id": "29e779dd-a096-4ef4-b810-9a8f0a80ef20",
+                "date": "2021-12-30",
+                "title": "日本のお城でタイムスリップイベント！武将や姫と一緒に時代を体験",
+                "img": "./img/img-domestic03.png",
+                "comments": [
+    
+                ]
+            },
+            {
+                "id": "29e779dd-a096-4ef4-b810-9a8f0a80ef21",
+                "date": "2022-1-3",
+                "title": "スカイツリーがロボットに変形！東京の新たなシンボルが登場",
+                "img": "./img/img-domestic04.png",
+                "comments": [
+                    {
+                        "id": "6b999dda-f0cb-443a-abe1-9158cc537ad9",
+                        "name": "takeda",
+                        "text": "It's so hard, my head is going to explode."
+                    },
+                    {
+                        "id": "6b999dda-f0cb-443a-abe1-9158cc537ad8",
+                        "name": "yamada",
+                        "text": "It's so hard, my head is going to explode."
+                    },
+                    {
+                        "id": "6b999dda-f0cb-443a-abe1-9158cc537ad7",
+                        "name": "takahashi",
+                        "text": "It's so hard, my head is going to explode."
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
# [Issue No.32](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#32)
記事一覧を作ります。 

## 今回の実装
- archive-news.htmlとarchive-news.jsの新規作成
- API からjsonデータをfetch()する
　→ jsonデータは、src/news.jsonで確認ができます。
- マークアップと大まかなCSSを書きましたが、こちらは未完成です。

## 未実装の仕様
- yahoo風コンテンツで作った同じAPIで全てのカテゴリーが一ページにリストとして収まる新規ページを作ってください
- そこには絞り込み機能があり、プルダウンからカテゴリーにマッチした記事が表示され他は非表示になります
- デザインは自由です

## [CodeSandBox](https://codesandbox.io/s/lesson32-fork-ver-p7zush?file=/src/js/archive-news.js)<br>
- forkが重たい時があるので、あらかじめfork版にしました。

## Concerns and areas to focus on
- Is fetch() error handling suitable?
