### PR TITLE
Lesson32-5: Selecting a category narrows down the list of articles in that category

### DIFF
--- a/lesson32/src/js/archive-news.js
+++ b/lesson32/src/js/archive-news.js
@@ -1,8 +1,9 @@
 import { createElementWithClassName } from "./modules/create-element";
 
+const selectElement = document.getElementById("js-select-category");
 const newsContent = document.getElementById("js-news-body");
 
-const url = "https://mocki.io/v1/fa320b21-de25-4521-bf1d-817ee178b80e";
+const url = "https://mocki.io/v1/216dc45c-ab5b-4b2f-94c7-7ca46e395a40";
 // const url = "https://mocki.io/v1/8cc57c74-d671-48ac-b59f-d3dfb73ec8c1"; //No data
 // const url = "https://httpstat.us/503"; // 503 error
 // const url = "https://mocki.io/v1/fafafafa"; // Failed to fetch
@@ -57,6 +58,7 @@ const init = async() => {
     } else {
         renderCategories(data);
         renderArticleList(data);
+        addEventForCategoryList(data);
     }
 };
 
@@ -71,10 +73,7 @@ const createOptionElements = data => {
     return fragment;
 };
 
-const renderCategories = data => {
-    const selectElement = document.getElementById("js-select-category");
-    selectElement.appendChild(createOptionElements(data));
-};
+const renderCategories = data => selectElement.appendChild(createOptionElements(data));
 
 const createArticleCards = data => {
     const fragment = document.createDocumentFragment();
@@ -111,13 +110,31 @@ const createThumbnail = article => {
     return thumbnailWrapper;
 };
 
-const renderArticleList = data => {
+const renderArticleList = (data, category = "all") => {
     const newsList = createElementWithClassName("ul", "news__list");
+    
+    if(category !== "all") {
+        data = filterArticlesData(data, category); 
+    }
+
     const fragment = document.createDocumentFragment();
     data.forEach(item => {
         fragment.appendChild(createArticleCards(item));
     })
-    newsContent.appendChild(newsList).appendChild(fragment);
+    newsContent.replaceChildren(newsList);
+    newsList.appendChild(fragment);
+};
+
+const filterArticlesData = (data, category) => {
+    const filteredData = data.filter(item => item.category === category);
+    return filteredData;
+};
+
+const addEventForCategoryList = data => {
+    selectElement.addEventListener("change", (e) => {
+        const selectedCategory = e.target.value;
+        renderArticleList(data, selectedCategory);
+    })
 };
 
 init();

--- a/lesson32/src/js/archive-news.js
+++ b/lesson32/src/js/archive-news.js
@@ -110,13 +110,9 @@ const createThumbnail = article => {
     return thumbnailWrapper;
 };
 
-const renderArticleList = (data, category = "all") => {
+const renderArticleList = data => {
     const newsList = createElementWithClassName("ul", "news__list");
     
-    if(category !== "all") {
-        data = filterArticlesData(data, category); 
-    }
-
     const fragment = document.createDocumentFragment();
     data.forEach(item => {
         fragment.appendChild(createArticleCards(item));
@@ -125,15 +121,16 @@ const renderArticleList = (data, category = "all") => {
     newsList.appendChild(fragment);
 };
 
-const filterArticlesData = (data, category) => {
-    const filteredData = data.filter(item => item.category === category);
-    return filteredData;
-};
-
 const addEventForCategoryList = data => {
     selectElement.addEventListener("change", (e) => {
         const selectedCategory = e.target.value;
-        renderArticleList(data, selectedCategory);
+        
+        if (selectedCategory === "all"){
+            renderArticleList(data);
+        } else {
+            const filteredData = data.filter(item => item.category === selectedCategory);
+            renderArticleList(filteredData);
+        }
     })
 };
 

--- a/lesson32/src/news.json
+++ b/lesson32/src/news.json
@@ -114,7 +114,7 @@
                 "id": "69e779dd-a096-4ef4-b810-9a8f0a80ef19",
                 "date": "2021-11-30",
                 "title": "世界最速のピザ配達！ジェットパックで空を飛ぶピザ屋が大ヒット",
-                "img": "./img/img-entertainment999.jpg",
+                "img": "./img/img-entertainment02.jpg",
                 "comments": []
             },
             {


### PR DESCRIPTION
# [Issue No.32](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#32)
記事一覧を作ります。 

## 今回の実装
- そこには絞り込み機能があり、プルダウンからカテゴリーにマッチした記事が表示され他は非表示になります

## 前回までの実装
- archive-news.htmlとarchive-news.jsの新規作成
- yahoo風コンテンツで作った同じAPIで全てのカテゴリーが一ページにリストとして収まる新規ページを作ってください
- デザインは自由です
- jsonデータにサムネイルのsrc情報が存在しない時はデフォルト画像を出力する（仕様外）

## 未実装の仕様
- archive-news.html にtokenチェックを実装する（確認が大変なので一旦外しています）

## [CodeSandBox](https://codesandbox.io/s/gracious-wescoff-7o68rp?file=/src/js/archive-news.js)<br>