### PR TITLE
Lesson32-8: Fixed keyboard transitions in forms

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/lesson32/package-lock.json
+++ b/lesson32/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "lesson32",
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "chance": "^1.1.11",
         "date-fns": "^2.29.3"

--- a/lesson32/src/css/style.css
+++ b/lesson32/src/css/style.css
@@ -751,6 +751,12 @@ body.is-drawer-active:after{
     opacity: 0.8;
 }
 
+.form__button input:focus:not([disabled]){	
+    cursor: pointer;
+    opacity: 0.8;
+    border: 2px solid #555fff;
+}
+
 .form__button + .form__text{
     margin-top: 50px;
 }

--- a/lesson32/src/js/drawer-menu.js
+++ b/lesson32/src/js/drawer-menu.js
@@ -1,19 +1,18 @@
+import { toggleInertAttribute } from "./modules/toggle-inert";
+
 const body = document.querySelector("body");
 const hamburgerButton = document.getElementById("js-hamburger-button");
 const drawerMenu = document.querySelector('[data-name="drawer-menu"]');
 const focusControlTargets = [document.getElementById("js-form"), document.getElementById("js-title")];
 
 const isOpen = (button) => button.getAttribute("aria-expanded") === "true";
-const toggleInertAttribute = (targets, boolean) => {
-    targets.forEach(target => {
-        target.inert = boolean;
-    })
-}
+
 const openMenu = (button, menu) => {
     body.classList.add("is-drawer-active");
     menu.classList.add("is-open");
     menu.setAttribute("aria-hidden", false);
     button.setAttribute("aria-expanded", true);
+    toggleInertAttribute([drawerMenu],false);
     toggleInertAttribute(focusControlTargets,true);
 }
 
@@ -22,6 +21,7 @@ const closeMenu = (button, menu) => {
     menu.classList.remove("is-open");
     menu.setAttribute("aria-hidden", true);
     button.setAttribute("aria-expanded", false);
+    toggleInertAttribute([drawerMenu],true);
     toggleInertAttribute(focusControlTargets,false);
 }
 

--- a/lesson32/src/js/drawer-menu.js
+++ b/lesson32/src/js/drawer-menu.js
@@ -3,8 +3,8 @@ import { toggleInertAttribute } from "./modules/toggle-inert";
 const body = document.querySelector("body");
 const hamburgerButton = document.getElementById("js-hamburger-button");
 const drawerMenu = document.querySelector('[data-name="drawer-menu"]');
-const focusControlTargets = [document.getElementById("js-form"), document.getElementById("js-title")];
-
+const form = document.getElementById("js-form");
+const title = document.getElementById("js-title");
 const isOpen = (button) => button.getAttribute("aria-expanded") === "true";
 
 const openMenu = (button, menu) => {
@@ -13,7 +13,7 @@ const openMenu = (button, menu) => {
     menu.setAttribute("aria-hidden", false);
     button.setAttribute("aria-expanded", true);
     toggleInertAttribute([drawerMenu],false);
-    toggleInertAttribute(focusControlTargets,true);
+    toggleInertAttribute([form, title],true);
 }
 
 const closeMenu = (button, menu) => {
@@ -22,7 +22,7 @@ const closeMenu = (button, menu) => {
     menu.setAttribute("aria-hidden", true);
     button.setAttribute("aria-expanded", false);
     toggleInertAttribute([drawerMenu],true);
-    toggleInertAttribute(focusControlTargets,false);
+    toggleInertAttribute([form, title],false);
 }
 
 hamburgerButton.addEventListener("click", (e) => {

--- a/lesson32/src/js/modules/toggle-inert.js
+++ b/lesson32/src/js/modules/toggle-inert.js
@@ -1,0 +1,5 @@
+export const toggleInertAttribute = (targets, boolean) => {
+    targets.forEach(target => {
+        target.inert = boolean;
+    })
+}

--- a/lesson32/src/js/register.js
+++ b/lesson32/src/js/register.js
@@ -1,22 +1,30 @@
 import { showErrorMessage,checkFormValidityInBlur, confirmIfCanSubmit } from "./modules/validation";
+import { toggleInertAttribute } from "./modules/toggle-inert";
 import { togglePasswordDisplay } from "./modules/togglepassword";
 
 const bodyElement = document.querySelector("body");
 const checkboxLink = document.getElementById("js-checkbox-link");
+const modal = document.getElementById("js-modal-area");
 const modalCloseButton = document.getElementById("js-modal-close-button");
 const modalInner = document.getElementById("js-modal-inner");
 const submitButton = document.querySelector(".js-submit-button");
 const invalidItems = document.getElementsByClassName("invalid");
+const focusControlTargets = [document.getElementById("js-form"), document.getElementById("js-header")];
 
 const openModal = () => {
     document.getElementById("js-modal-area").classList.add("is-active");
     bodyElement.classList.add("fixed");
     document.getElementById("js-modal-contents").scrollTop = 0;
+    toggleInertAttribute(focusControlTargets, true);
+    toggleInertAttribute([modal], false);
 };
 
 const closeModal = () => {
     document.getElementById("js-modal-area").classList.remove("is-active");
     bodyElement.classList.remove("fixed");
+    toggleInertAttribute(focusControlTargets, false);
+    toggleInertAttribute([modal], true);
+    submitButton.focus();
 };
 
 checkboxLink.addEventListener("click", openModal);

--- a/lesson32/src/js/register.js
+++ b/lesson32/src/js/register.js
@@ -50,6 +50,7 @@ const setCheckedAttributeToCheckbox = ([entry]) => {
         checkbox.disabled = false;
         checkbox.classList.remove("invalid");
         confirmIfCanSubmit(submitButton,invalidItems);
+        modalCloseButton.focus();
     }
 };
 

--- a/lesson32/src/js/register.js
+++ b/lesson32/src/js/register.js
@@ -9,20 +9,21 @@ const modalCloseButton = document.getElementById("js-modal-close-button");
 const modalInner = document.getElementById("js-modal-inner");
 const submitButton = document.querySelector(".js-submit-button");
 const invalidItems = document.getElementsByClassName("invalid");
-const focusControlTargets = [document.getElementById("js-form"), document.getElementById("js-header")];
+const form = document.getElementById("js-form");
+const header = document.getElementById("js-header");
 
 const openModal = () => {
     document.getElementById("js-modal-area").classList.add("is-active");
     bodyElement.classList.add("fixed");
     document.getElementById("js-modal-contents").scrollTop = 0;
-    toggleInertAttribute(focusControlTargets, true);
+    toggleInertAttribute([form, header], true);
     toggleInertAttribute([modal], false);
 };
 
 const closeModal = () => {
     document.getElementById("js-modal-area").classList.remove("is-active");
     bodyElement.classList.remove("fixed");
-    toggleInertAttribute(focusControlTargets, false);
+    toggleInertAttribute([form, header], false);
     toggleInertAttribute([modal], true);
     submitButton.focus();
 };

--- a/lesson32/src/login.html
+++ b/lesson32/src/login.html
@@ -16,7 +16,7 @@
         <header class="header" id="js-header">
             <div class="header__inner">
                 <h1 class="title top center" id="js-title"><a href="./" class="header__link">haru news</a></h1>
-                <nav class="header__nav" id="global-nav" data-name="drawer-menu" aria-hidden="true">
+                <nav class="header__nav" id="global-nav" data-name="drawer-menu" aria-hidden="true" inert>
                     <div class="header__nav-inner">
                         <ul class="header__nav-list">
                             <li class="header__nav-item"><a href="./register.html" class="header__link" tabindex="2">Sign up</a></li>
@@ -52,7 +52,7 @@
             </div>
             <div class="form__inner">
                 <div class="form__item">
-                    <label for="userid">User ID <span class="form__notion">(Name or E-mail)</span></label>
+                    <label for="userId">User ID <span class="form__notion">(Name or E-mail)</span></label>
                     <input type="text" class="form__item-input js-form-userid" id="userId" name="userId" tabindex="1" required>
                     <p class="error"></p>
                 </div>
@@ -61,9 +61,9 @@
                     <button class="form__eye js-eye-icon" aria-label="パスワードが表示されます" type="button" tabindex="3"></button><input type="password" class="form__item-input js-form-password" id="password" name="password" aria-describedby="confirm-password-constraints" tabindex="2" required>
                     <p class="error" id="confirm-password-constraints" data-name="password-error"></p>
                 </div>
-                <p class="form__text"><a class="link" href="./forgotpassword.html">パスワードをお忘れの方はこちら</a></p>
+                <p class="form__text"><a class="link" href="./forgotpassword.html" tabindex="4" data-testid="forgot-password-link">パスワードをお忘れの方はこちら</a></p>
                 <div class="form__button">
-                    <input type="button" name="submitButton" class="js-submit-button" value="Login" disabled>
+                    <input type="button" name="submitButton" class="js-submit-button" value="Login" tabindex="5" disabled>
                 </div>
             </div>
         </form>

--- a/lesson32/src/notautherize.html
+++ b/lesson32/src/notautherize.html
@@ -10,7 +10,7 @@
     <body>
         <section class="form box">
             <h1 class="title">User authentication failed.</h1>
-            <p class="register__text">権限がありません</p>
+            <p class="register__text" data-testid="not-auth-text">権限がありません</p>
             <p class="center form__anchor"><a href="./login.html" class="link">← Back to Login page</a></p>
         </section>
     </body>

--- a/lesson32/src/register-done.html
+++ b/lesson32/src/register-done.html
@@ -10,7 +10,7 @@
     <body>
         <section class="form box">
             <h1 class="title">Your registration is complete.</h1>
-            <p class="register__text">アカウント登録が完了しました。</p>
+            <p class="register__text" data-testid="complete-text">アカウント登録が完了しました。</p>
             <p class="center form__anchor"><a href="./" class="link">ログインページへ移動する</a></p>
         </section>
     </body>

--- a/lesson32/src/register.html
+++ b/lesson32/src/register.html
@@ -14,7 +14,7 @@
         <header class="header" id="js-header">
             <div class="header__inner">
                 <h1 class="title top center" id="js-title"><a href="./" class="header__link">haru news</a></h1>
-                <nav class="header__nav" id="global-nav" data-name="drawer-menu" aria-hidden="true">
+                <nav class="header__nav" id="global-nav" data-name="drawer-menu" aria-hidden="true" inert>
                     <div class="header__nav-inner">
                         <ul class="header__nav-list">
                             <li class="header__nav-item"><a href="./register.html" class="header__link" tabindex="2">Sign up</a></li>
@@ -67,11 +67,11 @@
                 </div>
                 <div class="form__check" id="js-checkbox-aria">
                     <input type="checkbox" name="answer" title="answer" value="利用規約に同意しました" id="js-checkbox" class="invalid" disabled>
-                    <span class="form__check-text"><button type="button" class="link form__terms" id="js-checkbox-link" data-testid="terms-link">利用規約</button>に同意しました</span>
+                    <span class="form__check-text"><button type="button" class="link form__terms" id="js-checkbox-link" data-testid="terms-link" tabindex="5">利用規約</button>に同意しました</span>
                     <p class="form__attention">( 規約を読むとチェックが入ります )</p>
                 </div>
                 <div class="form__button" data-testid="button-area">
-                    <input type="button" name="submitButton" class="js-submit-button" value="Create My Account" disabled>
+                    <input type="button" name="submitButton" class="js-submit-button" value="Create My Account" tabindex="6" disabled>
                 </div>
                 <p class="error" id="js-error-area" data-testid="error-area"></p>
             </div>
@@ -79,7 +79,7 @@
         <div class="modal js-modal" id="js-modal-area" role="dialog">
             <div class="modal__inner" id="js-modal-inner">
                 <button class="modal__close-button" id="js-modal-close-button" aria-label="Close"><img src="./img/icon-close.svg" alt="モーダルを閉じる" width="512" height="512" decoding="async"></button>
-                <div class="modal__contents" id="js-modal-contents" data-testid="modal-contents">
+                <div class="modal__contents" id="js-modal-contents" data-testid="modal-contents" tabindex="0">
                     <h2 class="modal__title">利用規約</h2>
                     <p class="modal__text">この利用規約（以下，「本規約」といいます。）は，＿＿＿＿＿（以下，「当社」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。</p>
                     <h3 class="modal__subtitle">第1条（適用）</h3>

--- a/lesson32/test/login.spec.js
+++ b/lesson32/test/login.spec.js
@@ -3,7 +3,6 @@ import { test, expect } from '@playwright/test';
 test('Correct keyboard transitions in the login form', async ({ page }) => {
     await page.goto('http://localhost:3000/login.html');
 
-    // const userIdArea = page.locator('#userId');
     const userIdArea = page.getByLabel('User ID (Name or E-mail)');
     const passwordArea = page.getByLabel('Password');
     const forgotPasswordLink = page.getByTestId('forgot-password-link');

--- a/lesson32/test/login.spec.js
+++ b/lesson32/test/login.spec.js
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test('Correct keyboard transitions in the login form', async ({ page }) => {
+    await page.goto('http://localhost:3000/login.html');
+
+    // const userIdArea = page.locator('#userId');
+    const userIdArea = page.getByLabel('User ID (Name or E-mail)');
+    const passwordArea = page.getByLabel('Password');
+    const forgotPasswordLink = page.getByTestId('forgot-password-link');
+    const submitButton = page.getByRole('button', { name: 'Login' });
+
+    // form tab遷移
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'メニューを開閉する' })).toBeFocused(); //hamburger button
+
+    await page.keyboard.press('Tab');
+    await expect(userIdArea).toBeFocused();
+    await userIdArea.fill('takeda');
+
+    await page.keyboard.press('Tab');
+    await expect(passwordArea).toBeFocused();
+    await passwordArea.fill('Fafafa0000');
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'パスワードが表示されます' })).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(forgotPasswordLink).toBeFocused();
+
+    // submitボタン tab遷移
+    await page.keyboard.press('Tab');
+    await expect(submitButton).toBeFocused();
+    page.keyboard.press('Enter');
+
+    await expect(page.getByTestId('not-auth-text')).toContainText('権限がありません');
+});

--- a/lesson32/test/register.spec.js
+++ b/lesson32/test/register.spec.js
@@ -1,5 +1,36 @@
 import { test, expect } from '@playwright/test';
 
+test('If your email address was already registered in the member registration, you will get an error', async ({ page }) => {
+    await page.goto('http://localhost:3000/register.html');
+
+    // 会員登録する
+    await page.getByLabel('UserName必須').fill('takeda');
+    await page.getByLabel('E-mail必須').fill('fafafa@sample.com');
+    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill('Fafafa0000');
+    await page.getByTestId('terms-link').click();
+    await page.getByTestId('modal-contents').click();
+    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
+    await page.getByRole('button', { name: 'Close' }).click();
+    await page.getByRole('button', { name: 'Create My Account' }).click();
+    await page.getByRole('link', { name: 'ログインページへ移動する' }).click();
+    await page.getByRole('link', { name: 'Sign Up' }).click();
+
+    // 再度同じメールアドレスで会員登録する
+    await page.getByLabel('UserName必須').fill('takeda');
+    await page.getByLabel('E-mail必須').fill('fafafa@sample.com');
+    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill('Fafafa0000');
+    await page.getByTestId('terms-link').click();
+    await page.getByTestId('modal-contents').click();
+    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
+    await page.getByRole('button', { name: 'Close' }).click();
+    await page.getByRole('button', { name: 'Create My Account' }).click();
+
+    const locator = page.getByTestId('error-area');
+    await expect(locator).toHaveText('既に登録済みのメールアドレスです');
+    await page.screenshot({ path: "./src/playwright/register/error-duplicate-entry.png", fullPage: true });
+});
+
+
 test('Correct keyboard transitions in the register form', async ({ page }) => {
     await page.goto('http://localhost:3000/register.html');
 

--- a/lesson32/test/register.spec.js
+++ b/lesson32/test/register.spec.js
@@ -1,93 +1,83 @@
 import { test, expect } from '@playwright/test';
 
 test('If your email address was already registered in the member registration, you will get an error', async ({page,}) => {
-  await page.goto('http://localhost:3000/register.html');
+    await page.goto('http://localhost:3000/register.html');
 
-  const name = 'takeda';
-  const email = 'fafafa@sample.com';
-  const password = 'Fafafa0000';
+    const name = 'takeda';
+    const email = 'fafafa@sample.com';
+    const password = 'Fafafa0000';
 
-  // 会員登録する
-  await page.getByLabel('UserName必須').fill(name);
-  await page.getByLabel('E-mail必須').fill(email);
-  await page
-    .getByLabel('Password ( 8文字以上の大小英数字 )必須')
-    .fill(password);
-  await page.getByTestId('terms-link').click();
-  await page.getByTestId('modal-contents').click();
-  await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
-  await page.getByRole('button', { name: 'Close' }).click();
-  await page.getByRole('button', { name: 'Create My Account' }).click();
-  await page.getByRole('link', { name: 'ログインページへ移動する' }).click();
-  await page.getByRole('link', { name: 'Sign Up' }).click();
+    // 会員登録する
+    await page.getByLabel('UserName必須').fill(name);
+    await page.getByLabel('E-mail必須').fill(email);
+    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill(password);
+    await page.getByTestId('terms-link').click();
+    await page.getByTestId('modal-contents').click();
+    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
+    await page.getByRole('button', { name: 'Close' }).click();
+    await page.getByRole('button', { name: 'Create My Account' }).click();
+    await page.getByRole('link', { name: 'ログインページへ移動する' }).click();
+    await page.getByRole('link', { name: 'Sign Up' }).click();
 
-  // 再度同じメールアドレスで会員登録する
-  await page.getByLabel('UserName必須').fill(name);
-  await page.getByLabel('E-mail必須').fill(email);
-  await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill(password);
-  await page.getByTestId('terms-link').click();
-  await page.getByTestId('modal-contents').click();
-  await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
-  await page.getByRole('button', { name: 'Close' }).click();
+    // 再度同じメールアドレスで会員登録する
+    await page.getByLabel('UserName必須').fill(name);
+    await page.getByLabel('E-mail必須').fill(email);
+    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill(password);
+    await page.getByTestId('terms-link').click();
+    await page.getByTestId('modal-contents').click();
+    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
+    await page.getByRole('button', { name: 'Close' }).click();
 
-  const button = page.getByRole('button', { name: 'Create My Account' });
-  await button.click();
-  await expect(button).toBeDisabled();
+    const button = page.getByRole('button', { name: 'Create My Account' });
+    await button.click();
+    await expect(button).toBeDisabled();
 
-  const errorArea = page.getByTestId('error-area');
-  await expect(errorArea).toHaveText('既に登録済みのメールアドレスです');
+    const errorArea = page.getByTestId('error-area');
+    await expect(errorArea).toHaveText('既に登録済みのメールアドレスです');
 });
 
 test('Correct keyboard transitions in the register form', async ({ page }) => {
-  await page.goto('http://localhost:3000/register.html');
+    await page.goto('http://localhost:3000/register.html');
 
-  const userNameArea = page.getByLabel('UserName必須');
-  const emailArea = page.getByLabel('E-mail必須');
-  const passwordArea = page.getByLabel(
-    'Password ( 8文字以上の大小英数字 )必須'
-  );
-  const modalCloseButton = page.getByRole('button', { name: 'Close' });
-  const modalContents = page.getByTestId('modal-contents');
-  const submitButton = page.getByRole('button', { name: 'Create My Account' });
+    const userNameArea = page.getByLabel('UserName必須');
+    const emailArea = page.getByLabel('E-mail必須');
+    const passwordArea = page.getByLabel('Password ( 8文字以上の大小英数字 )必須');
+    const modalCloseButton = page.getByRole('button', { name: 'Close' });
+    const modalContents = page.getByTestId('modal-contents');
+    const submitButton = page.getByRole('button', { name: 'Create My Account' });
 
-  // form tab遷移
-  await page.keyboard.press('Tab');
-  await expect(
-    page.getByRole('button', { name: 'メニューを開閉する' })
-  ).toBeFocused(); //hamburger button
+    // form tab遷移
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'メニューを開閉する' })).toBeFocused(); //hamburger button
 
-  await page.keyboard.press('Tab');
-  await expect(userNameArea).toBeFocused();
-  await userNameArea.fill('takeda');
+    await page.keyboard.press('Tab');
+    await expect(userNameArea).toBeFocused();
+    await userNameArea.fill('takeda');
 
-  await page.keyboard.press('Tab');
-  await expect(emailArea).toBeFocused();
-  await emailArea.fill('fafafa@sample.com');
+    await page.keyboard.press('Tab');
+    await expect(emailArea).toBeFocused();
+    await emailArea.fill('fafafa@sample.com');
 
-  await page.keyboard.press('Tab');
-  await expect(passwordArea).toBeFocused();
-  await passwordArea.fill('Fafafa0000');
+    await page.keyboard.press('Tab');
+    await expect(passwordArea).toBeFocused();
+    await passwordArea.fill('Fafafa0000');
 
-  await page.keyboard.press('Tab');
-  await expect(
-    page.getByRole('button', { name: 'パスワードが表示されます' })
-  ).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'パスワードが表示されます' })).toBeFocused();
 
-  await page.keyboard.press('Tab');
-  await expect(page.getByTestId('terms-link')).toBeFocused(); //利用規約リンク
-  await page.keyboard.press('Enter');
+    await page.keyboard.press('Tab');
+    await expect(page.getByTestId('terms-link')).toBeFocused(); //利用規約リンク
+    await page.keyboard.press('Enter');
 
-  // 利用規約モーダル内 tab遷移
-  await page.getByTestId('last-sentence').scrollIntoViewIfNeeded(); //最後の文章までスクロール
+    // 利用規約モーダル内 tab遷移
+    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded(); //最後の文章までスクロール
 
-  await expect(modalCloseButton).toBeFocused();
-  await page.keyboard.press('Enter');
+    await expect(modalCloseButton).toBeFocused();
+    await page.keyboard.press('Enter');
 
-  // submitボタン tab遷移
-  await expect(submitButton).toBeFocused();
-  page.keyboard.press('Enter');
+    // submitボタン tab遷移
+    await expect(submitButton).toBeFocused();
+    page.keyboard.press('Enter');
 
-  await expect(page.getByTestId('complete-text')).toContainText(
-    'アカウント登録が完了しました。'
-  );
+    await expect(page.getByTestId('complete-text')).toContainText('アカウント登録が完了しました。');
 });

--- a/lesson32/test/register.spec.js
+++ b/lesson32/test/register.spec.js
@@ -1,37 +1,53 @@
 import { test, expect } from '@playwright/test';
 
-test('If your email address was already registered in the member registration, you will get an error', async ({ page }) => {
+test('Correct keyboard transitions in the register form', async ({ page }) => {
     await page.goto('http://localhost:3000/register.html');
 
-    const name = 'takeda';
-    const email = 'fafafa@sample.com';
-    const password = 'Fafafa0000';
+    const userNameArea = page.getByLabel('UserName必須');
+    const emailArea = page.getByLabel('E-mail必須');
+    const passwordArea = page.getByLabel('Password ( 8文字以上の大小英数字 )必須');
+    const modalCloseButton = page.getByRole('button', { name: 'Close' });
+    const modalContents = page.getByTestId('modal-contents');
+    const submitButton = page.getByRole('button', { name: 'Create My Account' });
 
-    // 会員登録する
-    await page.getByLabel('UserName必須').fill(name);
-    await page.getByLabel('E-mail必須').fill(email);
-    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill(password);
-    await page.getByTestId('terms-link').click();
-    await page.getByTestId('modal-contents').click();
-    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
-    await page.getByRole('button', { name: 'Close' }).click();
-    await page.getByRole('button', { name: 'Create My Account' }).click();
-    await page.getByRole('link', { name: 'ログインページへ移動する' }).click();
-    await page.getByRole('link', { name: 'Sign Up' }).click();
+    // form tab遷移
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'メニューを開閉する' })).toBeFocused(); //hamburger button
 
-    // 再度同じメールアドレスで会員登録する
-    await page.getByLabel('UserName必須').fill(name);
-    await page.getByLabel('E-mail必須').fill(email);
-    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill(password);
-    await page.getByTestId('terms-link').click();
-    await page.getByTestId('modal-contents').click();
-    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
-    await page.getByRole('button', { name: 'Close' }).click();
+    await page.keyboard.press('Tab');
+    await expect(userNameArea).toBeFocused();
+    await userNameArea.fill('takeda');
 
-    const button = page.getByRole('button', { name: 'Create My Account' });
-    await button.click();
-    await expect(button).toBeDisabled();
+    await page.keyboard.press('Tab');
+    await expect(emailArea).toBeFocused();
+    await emailArea.fill('fafafa@sample.com');
 
-    const errorArea = page.getByTestId('error-area');
-    await expect(errorArea).toHaveText('既に登録済みのメールアドレスです');
+    await page.keyboard.press('Tab');
+    await expect(passwordArea).toBeFocused();
+    await passwordArea.fill('Fafafa0000');
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'パスワードが表示されます' })).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(page.getByTestId('terms-link')).toBeFocused(); //利用規約リンク
+    await page.keyboard.press('Enter');
+
+    // 利用規約モーダル内 tab遷移
+    await page.keyboard.press('Tab');
+    await expect(modalCloseButton).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(modalContents).toBeFocused();
+    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded(); //最後の文章までスクロール
+    
+    await page.keyboard.press('Tab');
+    await expect(modalCloseButton).toBeFocused();
+    await page.keyboard.press('Enter');
+
+    // submitボタン tab遷移
+    await expect(submitButton).toBeFocused();
+    page.keyboard.press('Enter');
+
+    await expect(page.getByTestId("complete-text")).toContainText('アカウント登録が完了しました。');
 });

--- a/lesson32/test/register.spec.js
+++ b/lesson32/test/register.spec.js
@@ -3,10 +3,14 @@ import { test, expect } from '@playwright/test';
 test('If your email address was already registered in the member registration, you will get an error', async ({ page }) => {
     await page.goto('http://localhost:3000/register.html');
 
+    const name = 'takeda';
+    const email = 'fafafa@sample.com';
+    const password = 'Fafafa0000';
+
     // 会員登録する
-    await page.getByLabel('UserName必須').fill('takeda');
-    await page.getByLabel('E-mail必須').fill('fafafa@sample.com');
-    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill('Fafafa0000');
+    await page.getByLabel('UserName必須').fill(name);
+    await page.getByLabel('E-mail必須').fill(email);
+    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill(password);
     await page.getByTestId('terms-link').click();
     await page.getByTestId('modal-contents').click();
     await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
@@ -16,18 +20,20 @@ test('If your email address was already registered in the member registration, y
     await page.getByRole('link', { name: 'Sign Up' }).click();
 
     // 再度同じメールアドレスで会員登録する
-    await page.getByLabel('UserName必須').fill('takeda');
-    await page.getByLabel('E-mail必須').fill('fafafa@sample.com');
-    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill('Fafafa0000');
+    await page.getByLabel('UserName必須').fill(name);
+    await page.getByLabel('E-mail必須').fill(email);
+    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill(password);
     await page.getByTestId('terms-link').click();
     await page.getByTestId('modal-contents').click();
     await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
     await page.getByRole('button', { name: 'Close' }).click();
-    await page.getByRole('button', { name: 'Create My Account' }).click();
 
-    const locator = page.getByTestId('error-area');
-    await expect(locator).toHaveText('既に登録済みのメールアドレスです');
-    await page.screenshot({ path: "./src/playwright/register/error-duplicate-entry.png", fullPage: true });
+    const button = page.getByRole('button', { name: 'Create My Account' });
+    await button.click();
+    await expect(button).toBeDisabled();
+
+    const errorArea = page.getByTestId('error-area');
+    await expect(errorArea).toHaveText('既に登録済みのメールアドレスです');
 });
 
 

--- a/lesson32/test/register.spec.js
+++ b/lesson32/test/register.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('If your email address was already registered in the member registration, you will get an error', async ({page,}) => {
+test('If your email address was already registered in the member registration, you will get an error', async ({ page }) => {
     await page.goto('http://localhost:3000/register.html');
 
     const name = 'takeda';

--- a/lesson32/test/register.spec.js
+++ b/lesson32/test/register.spec.js
@@ -1,90 +1,93 @@
 import { test, expect } from '@playwright/test';
 
-test('If your email address was already registered in the member registration, you will get an error', async ({ page }) => {
-    await page.goto('http://localhost:3000/register.html');
+test('If your email address was already registered in the member registration, you will get an error', async ({page,}) => {
+  await page.goto('http://localhost:3000/register.html');
 
-    const name = 'takeda';
-    const email = 'fafafa@sample.com';
-    const password = 'Fafafa0000';
+  const name = 'takeda';
+  const email = 'fafafa@sample.com';
+  const password = 'Fafafa0000';
 
-    // 会員登録する
-    await page.getByLabel('UserName必須').fill(name);
-    await page.getByLabel('E-mail必須').fill(email);
-    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill(password);
-    await page.getByTestId('terms-link').click();
-    await page.getByTestId('modal-contents').click();
-    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
-    await page.getByRole('button', { name: 'Close' }).click();
-    await page.getByRole('button', { name: 'Create My Account' }).click();
-    await page.getByRole('link', { name: 'ログインページへ移動する' }).click();
-    await page.getByRole('link', { name: 'Sign Up' }).click();
+  // 会員登録する
+  await page.getByLabel('UserName必須').fill(name);
+  await page.getByLabel('E-mail必須').fill(email);
+  await page
+    .getByLabel('Password ( 8文字以上の大小英数字 )必須')
+    .fill(password);
+  await page.getByTestId('terms-link').click();
+  await page.getByTestId('modal-contents').click();
+  await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
+  await page.getByRole('button', { name: 'Close' }).click();
+  await page.getByRole('button', { name: 'Create My Account' }).click();
+  await page.getByRole('link', { name: 'ログインページへ移動する' }).click();
+  await page.getByRole('link', { name: 'Sign Up' }).click();
 
-    // 再度同じメールアドレスで会員登録する
-    await page.getByLabel('UserName必須').fill(name);
-    await page.getByLabel('E-mail必須').fill(email);
-    await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill(password);
-    await page.getByTestId('terms-link').click();
-    await page.getByTestId('modal-contents').click();
-    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
-    await page.getByRole('button', { name: 'Close' }).click();
+  // 再度同じメールアドレスで会員登録する
+  await page.getByLabel('UserName必須').fill(name);
+  await page.getByLabel('E-mail必須').fill(email);
+  await page.getByLabel('Password ( 8文字以上の大小英数字 )必須').fill(password);
+  await page.getByTestId('terms-link').click();
+  await page.getByTestId('modal-contents').click();
+  await page.getByTestId('last-sentence').scrollIntoViewIfNeeded();
+  await page.getByRole('button', { name: 'Close' }).click();
 
-    const button = page.getByRole('button', { name: 'Create My Account' });
-    await button.click();
-    await expect(button).toBeDisabled();
+  const button = page.getByRole('button', { name: 'Create My Account' });
+  await button.click();
+  await expect(button).toBeDisabled();
 
-    const errorArea = page.getByTestId('error-area');
-    await expect(errorArea).toHaveText('既に登録済みのメールアドレスです');
+  const errorArea = page.getByTestId('error-area');
+  await expect(errorArea).toHaveText('既に登録済みのメールアドレスです');
 });
 
-
 test('Correct keyboard transitions in the register form', async ({ page }) => {
-    await page.goto('http://localhost:3000/register.html');
+  await page.goto('http://localhost:3000/register.html');
 
-    const userNameArea = page.getByLabel('UserName必須');
-    const emailArea = page.getByLabel('E-mail必須');
-    const passwordArea = page.getByLabel('Password ( 8文字以上の大小英数字 )必須');
-    const modalCloseButton = page.getByRole('button', { name: 'Close' });
-    const modalContents = page.getByTestId('modal-contents');
-    const submitButton = page.getByRole('button', { name: 'Create My Account' });
+  const userNameArea = page.getByLabel('UserName必須');
+  const emailArea = page.getByLabel('E-mail必須');
+  const passwordArea = page.getByLabel(
+    'Password ( 8文字以上の大小英数字 )必須'
+  );
+  const modalCloseButton = page.getByRole('button', { name: 'Close' });
+  const modalContents = page.getByTestId('modal-contents');
+  const submitButton = page.getByRole('button', { name: 'Create My Account' });
 
-    // form tab遷移
-    await page.keyboard.press('Tab');
-    await expect(page.getByRole('button', { name: 'メニューを開閉する' })).toBeFocused(); //hamburger button
+  // form tab遷移
+  await page.keyboard.press('Tab');
+  await expect(
+    page.getByRole('button', { name: 'メニューを開閉する' })
+  ).toBeFocused(); //hamburger button
 
-    await page.keyboard.press('Tab');
-    await expect(userNameArea).toBeFocused();
-    await userNameArea.fill('takeda');
+  await page.keyboard.press('Tab');
+  await expect(userNameArea).toBeFocused();
+  await userNameArea.fill('takeda');
 
-    await page.keyboard.press('Tab');
-    await expect(emailArea).toBeFocused();
-    await emailArea.fill('fafafa@sample.com');
+  await page.keyboard.press('Tab');
+  await expect(emailArea).toBeFocused();
+  await emailArea.fill('fafafa@sample.com');
 
-    await page.keyboard.press('Tab');
-    await expect(passwordArea).toBeFocused();
-    await passwordArea.fill('Fafafa0000');
+  await page.keyboard.press('Tab');
+  await expect(passwordArea).toBeFocused();
+  await passwordArea.fill('Fafafa0000');
 
-    await page.keyboard.press('Tab');
-    await expect(page.getByRole('button', { name: 'パスワードが表示されます' })).toBeFocused();
+  await page.keyboard.press('Tab');
+  await expect(
+    page.getByRole('button', { name: 'パスワードが表示されます' })
+  ).toBeFocused();
 
-    await page.keyboard.press('Tab');
-    await expect(page.getByTestId('terms-link')).toBeFocused(); //利用規約リンク
-    await page.keyboard.press('Enter');
+  await page.keyboard.press('Tab');
+  await expect(page.getByTestId('terms-link')).toBeFocused(); //利用規約リンク
+  await page.keyboard.press('Enter');
 
-    // 利用規約モーダル内 tab遷移
-    await page.keyboard.press('Tab');
-    await expect(modalCloseButton).toBeFocused();
+  // 利用規約モーダル内 tab遷移
+  await page.getByTestId('last-sentence').scrollIntoViewIfNeeded(); //最後の文章までスクロール
 
-    await page.keyboard.press('Tab');
-    await expect(modalContents).toBeFocused();
-    await page.getByTestId('last-sentence').scrollIntoViewIfNeeded(); //最後の文章までスクロール
-    
-    await page.keyboard.press('Tab');
-    await expect(modalCloseButton).toBeFocused();
-    await page.keyboard.press('Enter');
+  await expect(modalCloseButton).toBeFocused();
+  await page.keyboard.press('Enter');
 
-    // submitボタン tab遷移
-    await expect(submitButton).toBeFocused();
-    page.keyboard.press('Enter');
+  // submitボタン tab遷移
+  await expect(submitButton).toBeFocused();
+  page.keyboard.press('Enter');
 
-    await expect(page.getByTestId("complete-text")).toContainText('アカウント登録が完了しました。');
+  await expect(page.getByTestId('complete-text')).toContainText(
+    'アカウント登録が完了しました。'
+  );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "JavaScript-lessons",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "JavaScript-lessons",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
# [Issue No.32](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#32)
記事一覧を作ります。 

## 今回の実装
- 仕様は満たしていますが、ログイン画面と会員登録画面のTab遷移を改善しました。

## 前回までの実装
- archive-news.htmlとarchive-news.jsの新規作成
- yahoo風コンテンツで作った同じAPIで全てのカテゴリーが一ページにリストとして収まる新規ページを作ってください
- デザインは自由です
- jsonデータにサムネイルのsrc情報が存在しない時はデフォルト画像を出力する（仕様外）
- そこには絞り込み機能があり、プルダウンからカテゴリーにマッチした記事が表示され他は非表示になります
- archive-news.html にtokenチェックを実装する

## [StackBulitz](https://stackblitz.com/edit/node-wqmtel?file=src%2Fjs%2Fdrawer-menu.js)
