### PR TITLE
Lesson34-4: Implemented modifications to previous PR

### DIFF
--- a/src/lesson34/article.html
+++ b/src/lesson34/article.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link href="./css/reset.css" rel="stylesheet">
     <link href="./css/style.css" rel="stylesheet">
+    <script>if (!localStorage.getItem("token")) window.location.href = "./login.html";</script>
     <script type="module" src="./js/article.js"></script>
     <title></title>
   </head>

--- a/src/lesson34/js/article.js
+++ b/src/lesson34/js/article.js
@@ -148,20 +148,30 @@ const changeButtonDisabled = target => {
     starImage.src = '/assets/img/icon-star-done.png';
 }
 
+
+const createFavoriteData = data => {
+    const favoriteData = {
+        'id': data.id,
+        'date': data.date,
+        'title': data.title,
+        'img': data.img,
+        'webp': data.webp
+    }
+    
+    let registeredFavoriteData;
+    try {
+        registeredFavoriteData = JSON.parse(localStorage.getItem('registeredFavoriteData'));
+    } catch (error) {
+        console.log(`jsonパースでエラーが発生しました: ${error}`);
+    }
+
+    const newFavoriteData = registeredFavoriteData !== null ? [...registeredFavoriteData, favoriteData] : [favoriteData];
+    return newFavoriteData;
+}
+
 const saveArticleData = data => {
     const targetData = getArticleData(data);
-    const favoriteArticleData = {
-        [targetData.id]: {
-            'date': targetData.date,
-            'title': targetData.title,
-            'img': targetData.img,
-            'webp': targetData.webp
-        }
-    }
-    const registeredFavoriteData = JSON.parse(localStorage.getItem("registeredFavoriteData"));
-    const newFavoriteData = registeredFavoriteData ? {...registeredFavoriteData, ...favoriteArticleData} : favoriteArticleData;
-    
-    localStorage.setItem("registeredFavoriteData", JSON.stringify(newFavoriteData));
+    localStorage.setItem("registeredFavoriteData", JSON.stringify(createFavoriteData(targetData)));
 }
 
 const renderArticle = data => {

--- a/src/lesson34/js/article.js
+++ b/src/lesson34/js/article.js
@@ -163,6 +163,8 @@ const createFavoriteData = data => {
         registeredFavoriteData = JSON.parse(localStorage.getItem('registeredFavoriteData'));
     } catch (error) {
         console.log(`jsonパースでエラーが発生しました: ${error}`);
+        displayInfo(articleWrapper,'エラーが発生しました');
+        return;
     }
 
     const newFavoriteData = registeredFavoriteData !== null ? [...registeredFavoriteData, favoriteData] : [favoriteData];


### PR DESCRIPTION
# [Issue No.34](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#34)
- ニュース詳細ページとお気に入り機能を作成する課題です


## 今回実装した仕様
前回のPRの修正
https://github.com/haru-programming/JavaScript-lessons/pull/68
- ニュース記事ページにtokenチェックを追加<br>
- 新しいお気に入り記事データの作成関数にnullチェックを追加<br>
- json.parse()時にtry,catch..を使用<br>

## 前回までに実装済みの仕様
- yahoo風コンテンツのそれぞれのリンク先、個別記事ページを作り、個別記事ページ上部に星マークのアイコンをつける
- 個別ページへのリンクは**.html?id=8b5ae244-cddb-4b94-a5cd-b1ca4201c948のように パラメーターにそれぞれの記事のidを追加
- 個別ページはリンクのパラメータidをもとに必要情報を取得する
- 星マークを押下するとお気に入りに登録されます
- その記事idと記事タイトル。リンク先。など必要だと思う要素をローカルストレージに保存

## 未実装の仕様
- 次に同じ個別ページを訪れた時(yahoo風のコンテンツAPIを取得する時)には ローカルストレージにidがあれば星アイコンをdisabledにしてください
- マイページに遷移すると個別ページのお気に入りのリストが並んでいます
- マイページにはメールアドレス再設定のリンクとお気に入りの解除機能を追加してください


## [StackBlitz](https://stackblitz.com/edit/stackblitz-starters-7xwkju?file=src%2Flesson34%2Fjs%2Farticle.js)
