### PR TITLE
Lesson34-5: Disable the favorite button by default if the article registered

### DIFF
--- a/src/lesson34/js/article.js
+++ b/src/lesson34/js/article.js
@@ -155,9 +155,7 @@ const getRegisteredFavoriteData = () => {
     } catch (error) {
         console.log(`jsonパースでエラーが発生しました: ${error}`);
         displayInfo(articleWrapper,'エラーが発生しました');
-        return;
     }
-
     return registeredFavoriteData;
 }
 
@@ -171,7 +169,7 @@ const createFavoriteData = data => {
     }
     
     const registeredFavoriteData = getRegisteredFavoriteData();
-    const newFavoriteData = registeredFavoriteData !== null ? [...registeredFavoriteData, favoriteData] : [favoriteData];
+    const newFavoriteData = registeredFavoriteData != null ? [...registeredFavoriteData, favoriteData] : [favoriteData];
     return newFavoriteData;
 }
 
@@ -182,7 +180,7 @@ const saveArticleData = data => {
 
 const isRegisteredData = () => {
     const registeredFavoriteData = getRegisteredFavoriteData();
-    return registeredFavoriteData !== null && registeredFavoriteData.some(item => item.id === urlParameter.id);
+    return registeredFavoriteData != null && registeredFavoriteData.some(item => item.id === urlParameter.id);
 }
 
 const renderArticle = data => {

--- a/src/lesson34/js/article.js
+++ b/src/lesson34/js/article.js
@@ -149,7 +149,7 @@ const changeButtonDisabled = target => {
 }
 
 const getRegisteredFavoriteData = () => {
-    let registeredFavoriteData;
+    let registeredFavoriteData = null;
     try {
         registeredFavoriteData = JSON.parse(localStorage.getItem('registeredFavoriteData'));
     } catch (error) {
@@ -169,7 +169,7 @@ const createFavoriteData = data => {
     }
     
     const registeredFavoriteData = getRegisteredFavoriteData();
-    const newFavoriteData = registeredFavoriteData != null ? [...registeredFavoriteData, favoriteData] : [favoriteData];
+    const newFavoriteData = registeredFavoriteData !== null ? [...registeredFavoriteData, favoriteData] : [favoriteData];
     return newFavoriteData;
 }
 
@@ -180,7 +180,7 @@ const saveArticleData = data => {
 
 const isRegisteredData = () => {
     const registeredFavoriteData = getRegisteredFavoriteData();
-    return registeredFavoriteData != null && registeredFavoriteData.some(item => item.id === urlParameter.id);
+    return registeredFavoriteData !== null && registeredFavoriteData.some(item => item.id === urlParameter.id);
 }
 
 const renderArticle = data => {

--- a/src/lesson34/js/article.js
+++ b/src/lesson34/js/article.js
@@ -148,6 +148,18 @@ const changeButtonDisabled = target => {
     starImage.src = '/assets/img/icon-star-done.png';
 }
 
+const getRegisteredFavoriteData = () => {
+    let registeredFavoriteData;
+    try {
+        registeredFavoriteData = JSON.parse(localStorage.getItem('registeredFavoriteData'));
+    } catch (error) {
+        console.log(`jsonパースでエラーが発生しました: ${error}`);
+        displayInfo(articleWrapper,'エラーが発生しました');
+        return;
+    }
+
+    return registeredFavoriteData;
+}
 
 const createFavoriteData = data => {
     const favoriteData = {
@@ -158,15 +170,7 @@ const createFavoriteData = data => {
         'webp': data.webp
     }
     
-    let registeredFavoriteData;
-    try {
-        registeredFavoriteData = JSON.parse(localStorage.getItem('registeredFavoriteData'));
-    } catch (error) {
-        console.log(`jsonパースでエラーが発生しました: ${error}`);
-        displayInfo(articleWrapper,'エラーが発生しました');
-        return;
-    }
-
+    const registeredFavoriteData = getRegisteredFavoriteData();
     const newFavoriteData = registeredFavoriteData !== null ? [...registeredFavoriteData, favoriteData] : [favoriteData];
     return newFavoriteData;
 }
@@ -174,6 +178,11 @@ const createFavoriteData = data => {
 const saveArticleData = data => {
     const targetData = getArticleData(data);
     localStorage.setItem("registeredFavoriteData", JSON.stringify(createFavoriteData(targetData)));
+}
+
+const isRegisteredData = () => {
+    const registeredFavoriteData = getRegisteredFavoriteData();
+    return registeredFavoriteData !== null && registeredFavoriteData.some(item => item.id === urlParameter.id);
 }
 
 const renderArticle = data => {
@@ -184,6 +193,11 @@ const renderArticle = data => {
     articleElement.appendChild(createArticleHead(targetData)).after(createArticleInfo(targetData));
     articleElement.appendChild(createArticleContents(targetData)).after(createThumbnail(targetData));
     renderCategory(data);
+
+    if(isRegisteredData()){
+        const favoriteButton = document.getElementById('js-favorite-button');
+        changeButtonDisabled(favoriteButton);
+    }
 }
 
 const addEventListenerForFavoriteButton = data => {


### PR DESCRIPTION
# [Issue No.34](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#34)
- ニュース詳細ページとお気に入り機能を作成する課題です


## 今回実装した仕様
- 次に同じ個別ページを訪れた時には ローカルストレージにidがあれば星アイコンをdisabledにしてください

## 前回までに実装済みの仕様
- yahoo風コンテンツのそれぞれのリンク先、個別記事ページを作り、個別記事ページ上部に星マークのアイコンをつける
- 個別ページへのリンクは**.html?id=8b5ae244-cddb-4b94-a5cd-b1ca4201c948のように パラメーターにそれぞれの記事のidを追加
- 個別ページはリンクのパラメータidをもとに必要情報を取得する
- 星マークを押下するとお気に入りに登録されます
- その記事idと記事タイトル。リンク先。など必要だと思う要素をローカルストレージに保存

## 未実装の仕様

- マイページに遷移すると個別ページのお気に入りのリストが並んでいます
- マイページにはメールアドレス再設定のリンクとお気に入りの解除機能を追加してください

## 動作確認
※お手数をおかけいたします。

1️⃣  会員登録→ログイン
2️⃣  ”ニュース記事一覧へ移動” リンクからニュース一覧へ移動
3️⃣ それぞれ個別ページに飛び、お気に入りボタンを押すと星が白→黒色になる
4️⃣ 記事一覧に戻り、同じ個別ページに飛ぶとお気に入りボタンはデフォルトで黒色なことを確認


## [StackBlitz](https://stackblitz.com/edit/stackblitz-starters-7xwkju?file=src%2Flesson34%2Fjs%2Farticle.js)
