### PR TITLE
Lesson34-6:  Create mypage and display favorite article list

### DIFF
--- a/src/lesson34/css/style.css
+++ b/src/lesson34/css/style.css
@@ -1338,7 +1338,7 @@ body.is-drawer-active:after{
     }
     
     .news__list{
-        gap: 9vw 5vw;
+        gap: 9vw 4.7vw;
     }
     
     .news__item{

--- a/src/lesson34/css/style.css
+++ b/src/lesson34/css/style.css
@@ -598,6 +598,25 @@ body.is-drawer-active:after{
     
 }
 
+/* -----------------------------------------------------------------
+// mypage
+// ---------------------------------------------------------------*/
+
+.mypage__inner{
+  max-width: 1000px;
+  margin-inline: auto;
+}
+
+.mypage__anchor{
+  display: flex;gap: 15px;
+  width: fit-content;
+  margin: 40px 40px 0 auto;
+}
+
+.mypage__body{
+  margin-top: 80px;
+}
+
 
 /* -----------------------------------------------------------------
 // form
@@ -1188,8 +1207,7 @@ body.is-drawer-active:after{
     }
 
     .user-menu__list{
-        height: 12vw;
-        padding: 2vw 1vw;
+        padding: 3vw 1vw;
         margin-top: 6vw;
     }
 
@@ -1232,7 +1250,7 @@ body.is-drawer-active:after{
     
     .setting__menu-item{
         padding: 0 3vw;
-        font-size: 3.3vw;
+        font-size: 2.8vw;
     }
 
     .setting__img >img{
@@ -1312,7 +1330,7 @@ body.is-drawer-active:after{
 
     .news__pulldown {
         padding: 1vw 8vw 1vw 2vw;
-    }    
+    }
     
     .news__body{
         padding: 10vw 4vw;
@@ -1320,7 +1338,7 @@ body.is-drawer-active:after{
     }
     
     .news__list{
-        gap: 9vw 4.6vw;
+        gap: 9vw 5vw;
     }
     
     .news__item{
@@ -1347,6 +1365,20 @@ body.is-drawer-active:after{
     .news__item-title{
         margin-top: 1.8vw;
         font-size: 2.2vw;
+    }
+
+    .mypage__inner{
+      width: 100%;
+    }
+
+    .mypage__anchor{
+      gap: 3vw;
+      margin: 7vw auto 0 auto;
+      transform: translateX(1.2vw);
+    }
+
+    .mypage__body{
+      margin-top: 12vw;
     }
     
     .tab {

--- a/src/lesson34/index.html
+++ b/src/lesson34/index.html
@@ -24,6 +24,7 @@
                 <p class="user-menu__name" id="js-username"></p>
                 <p class="user-menu__email" id="js-email"></p>
                 <ul class="user-menu__list">
+                    <li class="user-menu__item"><a href="./mypage.html" class="link">マイページ</a></li>
                     <li class="user-menu__item"><a href="./reset-email.html" class="link">メールアドレス変更</a></li>
                     <li class="user-menu__item"><a href="./reset-password.html" class="link">パスワード変更</a></li>
                 </ul>

--- a/src/lesson34/js/mypage.js
+++ b/src/lesson34/js/mypage.js
@@ -1,0 +1,77 @@
+import { createElementWithClassName } from "./modules/create-element";
+
+const articleWrapper = document.getElementById("js-mypage");
+
+const displayInfo = (target, error) => {
+  const p = document.createElement("p");
+  p.textContent = error;
+  target.appendChild(p);
+};
+
+const getFavoriteData = () => {
+    let favoriteData = null;
+    try {
+      favoriteData = JSON.parse(localStorage.getItem('registeredFavoriteData'));
+    } catch (error) {
+        console.log(`jsonパースでエラーが発生しました: ${error}`);
+        displayInfo(articleWrapper,'エラーが発生しました');
+    }
+    return favoriteData;
+};
+
+const init = () => {
+  const favoriteData = getFavoriteData();
+  if (favoriteData === null ) return;
+
+  renderArticleList(favoriteData);
+};
+
+const createArticleCards = data => {
+  const fragment = document.createDocumentFragment();
+
+  const newsItem = createElementWithClassName("li", "news__item");
+  const infoArea = createElementWithClassName("div", "news__item-info");
+  const date = createElementWithClassName("p", "news__item-date");
+  const title = createElementWithClassName("h3", "news__item-title"); 
+  const titleLink = createElementWithClassName("a", "news__item-link");
+  const hrefWithId = `./article.html?id=${data.id}`;
+
+  date.textContent = data.date;
+  titleLink.textContent = data.title;
+  titleLink.href = hrefWithId;
+  titleLink.classList.add("link");
+
+  infoArea.appendChild(date);
+  title.appendChild(titleLink);
+  fragment.appendChild(newsItem).appendChild(title).after(infoArea, createThumbnail(data));
+  return fragment;
+};
+
+const createThumbnail = article => {
+  const thumbnailWrapper = createElementWithClassName("picture", "news__item-thumbnail-wrap");
+  const thumbnailWebp = createElementWithClassName("source", "news__item-thumbnail");
+  const thumbnailJpg = createElementWithClassName("img", "news__item-thumbnail");
+  const noImgSrc = "/assets/img/no-img.jpg";
+
+  thumbnailJpg.alt = "";
+  thumbnailJpg.src = article.img || noImgSrc;
+  thumbnailWrapper.appendChild(thumbnailJpg);
+
+  if(article.webp){
+    thumbnailWebp.srcset = article.webp;
+    thumbnailWrapper.insertAdjacentElement("afterbegin", thumbnailWebp);
+  }
+  return thumbnailWrapper;
+};
+
+const renderArticleList = data => {
+  const articleList = createElementWithClassName("ul", "news__list");
+  
+  const fragment = document.createDocumentFragment();
+  data.forEach(item => {
+      fragment.appendChild(createArticleCards(item));
+  })
+  articleWrapper.appendChild(articleList).appendChild(fragment);
+};
+
+init();

--- a/src/lesson34/mypage.html
+++ b/src/lesson34/mypage.html
@@ -7,9 +7,9 @@
         <link rel="stylesheet" href="./css/reset.css" type="text/css">
         <link rel="stylesheet" href="./css/style.css" type="text/css">
         <script>if (!localStorage.getItem("token")) window.location.href = "./login.html";</script>
-        <script type="module" src="./js/contents/main.js" defer></script>
-        <script type="module" src="./js/archive-news.js"></script>
-        <title>ニュース一覧</title>
+        <script type="module" src="./js/contents/main.js"></script>
+        <script type="module" src="./js/mypage.js"></script>
+        <title>マイページ</title>
     </head>
     <body>
         <header class="header">
@@ -30,20 +30,13 @@
                 <button class="user-menu__button" id="js-logout-button" type="button">Logout</button>
             </div>
         </header>
-        <section class="news">
-            <div class="news__inner">
-                <div class="news__head">
-                    <h2 class="title sub">ニュース記事一覧</h2>
-                    <div class="news__select">
-                        <label for="select-category">カテゴリー検索</label>
-                        <div class="news__pulldown-wrapper">
-                            <select class="news__pulldown js-select-category" id="select-category">
-                                <option value="all">すべて</option>
-                            </select>
-                        </div>
-                    </div>
+        <section class="mypage">
+            <div class="mypage__inner">
+                <div class="mypage__head">
+                    <h2 class="title sub">マイページ</h2>
+                    <div class="mypage__anchor"><a href="./archive-news.html" class="link">ニュース記事一覧</a> | <a href="./reset-email.html" class="link">メールアドレス変更</a></div>
                 </div>
-                <div class="news__body" id="js-news-body"></div>
+                <div class="mypage__body news" id="js-mypage"></div>
             </div>
         </section>
     </body>

--- a/src/lesson34/reset-email.html
+++ b/src/lesson34/reset-email.html
@@ -23,6 +23,7 @@
                 <p class="user-menu__name" id="js-username"></p>
                 <p class="user-menu__email" id="js-email"></p>
                 <ul class="user-menu__list">
+                    <li class="user-menu__item"><a href="./mypage.html" class="link">マイページ</a></li>
                     <li class="user-menu__item"><a href="./reset-email.html" class="link">メールアドレス変更</a></li>
                     <li class="user-menu__item"><a href="./reset-password.html" class="link">パスワード変更</a></li>
                 </ul>

--- a/src/lesson34/reset-password.html
+++ b/src/lesson34/reset-password.html
@@ -23,6 +23,7 @@
                 <p class="user-menu__name" id="js-username"></p>
                 <p class="user-menu__email" id="js-email"></p>
                 <ul class="user-menu__list">
+                    <li class="user-menu__item"><a href="./mypage.html" class="link">マイページ</a></li>
                     <li class="user-menu__item"><a href="./reset-email.html" class="link">メールアドレス変更</a></li>
                     <li class="user-menu__item"><a href="./reset-password.html" class="link">パスワード変更</a></li>
                 </ul>


### PR DESCRIPTION
# [Issue No.34](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#34)
- ニュース詳細ページとお気に入り機能を作成する課題です


## 今回実装した仕様
- マイページに遷移すると個別ページのお気に入りのリストが並んでいます
- マイページにはメールアドレス再設定のリンクを追加してください


## 前回までに実装済みの仕様
- yahoo風コンテンツのそれぞれのリンク先、個別記事ページを作り、個別記事ページ上部に星マークのアイコンをつける
- 個別ページへのリンクは**.html?id=8b5ae244-cddb-4b94-a5cd-b1ca4201c948のように パラメーターにそれぞれの記事のidを追加
- 個別ページはリンクのパラメータidをもとに必要情報を取得する
- 星マークを押下するとお気に入りに登録されます
- その記事idと記事タイトル。リンク先。など必要だと思う要素をローカルストレージに保存
- 次に同じ個別ページを訪れた時には ローカルストレージにidがあれば星アイコンをdisabledにしてください

## 未実装の仕様
- マイページにはお気に入りの解除機能を追加してください

## 動作確認  [StackBlitz](https://stackblitz.com/edit/stackblitz-starters-7xwkju?file=src%2Flesson34%2Fjs%2Farticle.js)
※お手数をおかけいたします。

1️⃣  会員登録→ログイン
2️⃣  ”ニュース記事一覧へ移動” リンクからニュース一覧へ移動
3️⃣ お好きな個別ページに飛び、お気に入りボタン（⭐️）を押してお気に入りに追加する。
4️⃣ユーザーメニューから「マイページ」に飛ぶ
![Screenshot by Dropbox Capture](https://github.com/haru-programming/JavaScript-lessons/assets/67426438/09a74057-81a4-46a8-8b7b-e74ef9f1873c)

5️⃣ お気に入りに追加した記事がマイページに表示されていることを確認

6️⃣ マイページ内のリンクが正しく遷移できるか確認
![Screenshot by Dropbox Capture](https://github.com/haru-programming/JavaScript-lessons/assets/67426438/93e5482f-3661-46c5-926f-c6383a3f26a1)

