### PR TITLE
feat: Added the ability to delete favorite articles

### DIFF
--- a/src/lesson34/css/style.css
+++ b/src/lesson34/css/style.css
@@ -541,7 +541,7 @@ body.is-drawer-active:after{
 }
 
 .news__item:hover{
-    opacity: 0.7;
+    opacity: 0.8;
 }
 
 .news__item:hover .news__item-thumbnail{
@@ -595,8 +595,30 @@ body.is-drawer-active:after{
     left: 0;
     width: 100%;
     height: 100%;
-    
 }
+
+.news__button{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    order: 4;
+    position: relative;
+    z-index: 20;
+    cursor: pointer;
+    width: 100%;
+    padding: 2px 20px;
+    margin: 15px 0 0 auto;
+    font-size: 14px;
+    letter-spacing: 0.02em;
+    border: 1px solid currentColor;
+    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out;
+}
+
+.news__button:hover{
+    color: #fff;
+    background-color: #5e5e5e;
+}
+
 
 /* -----------------------------------------------------------------
 // mypage

--- a/src/lesson34/css/style.css
+++ b/src/lesson34/css/style.css
@@ -1358,6 +1358,10 @@ body.is-drawer-active:after{
         padding: 10vw 4vw;
         border-radius: 0 0 2vw 2vw;
     }
+
+    .news__button{
+        font-size: 2.2vw;
+    }
     
     .news__list{
         gap: 9vw 4.7vw;
@@ -1401,6 +1405,7 @@ body.is-drawer-active:after{
 
     .mypage__body{
       margin-top: 12vw;
+      font-size: 2.8vw;
     }
     
     .tab {

--- a/src/lesson34/js/mypage.js
+++ b/src/lesson34/js/mypage.js
@@ -21,19 +21,22 @@ const getFavoriteData = () => {
 
 const init = () => {
   const favoriteData = getFavoriteData();
-  if (favoriteData === null ) return;
-
+  if (favoriteData.length === 0) {
+    displayInfo(articleWrapper,'お気に入り記事がありません。');
+    return;
+  }
   renderArticleList(favoriteData);
+  addEventListenerForRemoveFavoriteButton();
 };
 
 const createArticleCards = data => {
   const fragment = document.createDocumentFragment();
 
-  const newsItem = createElementWithClassName("li", "news__item");
+  const newsItem = createElementWithClassName("li", "news__item js-article");
   const infoArea = createElementWithClassName("div", "news__item-info");
   const date = createElementWithClassName("p", "news__item-date");
   const title = createElementWithClassName("h3", "news__item-title"); 
-  const titleLink = createElementWithClassName("a", "news__item-link");
+  const titleLink = createElementWithClassName("a", "news__item-link js-article-link");
   const hrefWithId = `./article.html?id=${data.id}`;
 
   date.textContent = data.date;
@@ -43,7 +46,7 @@ const createArticleCards = data => {
 
   infoArea.appendChild(date);
   title.appendChild(titleLink);
-  fragment.appendChild(newsItem).appendChild(title).after(infoArea, createThumbnail(data));
+  fragment.appendChild(newsItem).appendChild(title).after(infoArea, createThumbnail(data), createRemoveFavoriteButton());
   return fragment;
 };
 
@@ -64,14 +67,50 @@ const createThumbnail = article => {
   return thumbnailWrapper;
 };
 
+const createRemoveFavoriteButton = () => {
+  const removeFavoriteButton = createElementWithClassName("button", "news__button js-remove-favorite-button");
+  removeFavoriteButton.type = "button";
+  removeFavoriteButton.textContent = "お気に入りから削除";
+  return removeFavoriteButton;
+}
+
 const renderArticleList = data => {
-  const articleList = createElementWithClassName("ul", "news__list");
+  const articleList = createElementWithClassName("ul", "news__list js-article-list");
   
   const fragment = document.createDocumentFragment();
   data.forEach(item => {
       fragment.appendChild(createArticleCards(item));
   })
   articleWrapper.appendChild(articleList).appendChild(fragment);
+};
+
+const getArticleId = target => {
+  const targetArticle = target.closest(".js-article");
+  const targetArticleLink = targetArticle.querySelector(".js-article-link").href;
+  const regex = /id=([^&]+)/;
+  const articleID = targetArticleLink.match(regex)[1];
+  return articleID;
+}
+
+const deleteArticleData = target => {
+  let registeredFavoriteData = getFavoriteData();
+  const targetIndex = registeredFavoriteData.findIndex(item => item.id === getArticleId(target));
+
+  registeredFavoriteData.splice(targetIndex, 1);
+  localStorage.setItem("registeredFavoriteData", JSON.stringify(registeredFavoriteData));
+  target.closest(".js-article").remove();
+}
+
+const addEventListenerForRemoveFavoriteButton = () => {
+  const articleList = document.querySelector(".js-article-list");
+
+  articleList.addEventListener("click", (e) => {
+    deleteArticleData(e.target);
+
+    if (getFavoriteData().length === 0) {
+      displayInfo(articleWrapper,'お気に入り記事がありません。');
+    }
+  });
 };
 
 init();


### PR DESCRIPTION
# [Issue No.34](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#34)
- ニュース詳細ページとお気に入り機能を作成する課題です


## 今回実装した仕様
- マイページにはお気に入りの解除機能を追加してください


## 前回までに実装済みの仕様
- yahoo風コンテンツのそれぞれのリンク先、個別記事ページを作り、個別記事ページ上部に星マークのアイコンをつける
- 個別ページへのリンクは**.html?id=8b5ae244-cddb-4b94-a5cd-b1ca4201c948のように パラメーターにそれぞれの記事のidを追加
- 個別ページはリンクのパラメータidをもとに必要情報を取得する
- 星マークを押下するとお気に入りに登録されます
- その記事idと記事タイトル。リンク先。など必要だと思う要素をローカルストレージに保存
- 次に同じ個別ページを訪れた時には ローカルストレージにidがあれば星アイコンをdisabledにしてください
- マイページに遷移すると個別ページのお気に入りのリストが並んでいます
- マイページにはメールアドレス再設定のリンクを追加してください

## 未実装の仕様
- なし

## 動作確認  [StackBlitz](https://stackblitz.com/edit/stackblitz-starters-7xwkju?file=src%2Flesson34%2Fjs%2Farticle.js)
※お手数をおかけいたします。

1️⃣  会員登録→ログイン
2️⃣  ”ニュース記事一覧へ移動” リンクからニュース一覧へ移動
3️⃣ お好きな個別ページに飛び、お気に入りボタン（⭐️）を押してお気に入りに追加する。
4️⃣ ユーザーメニューから「マイページ」に飛ぶ
![Screenshot by Dropbox Capture](https://github.com/haru-programming/JavaScript-lessons/assets/67426438/09a74057-81a4-46a8-8b7b-e74ef9f1873c)

5️⃣ お気に入りに追加した記事がマイページに表示されていることを確認

6️⃣ マイページにあるお気に入り記事の「お気に入りから削除」ボタンを押すと、記事が削除される。（今回新しくご確認いただきたい部分です）
