### PR TITLE
Improvement: Display news titles from json data unified with others in yahoo-like tab UI.

### DIFF
--- a/src/lesson34/css/style.css
+++ b/src/lesson34/css/style.css
@@ -1028,6 +1028,7 @@ body.is-drawer-active:after{
 .tab__nav-list {
     display: flex;
     justify-content: space-around;
+    position: relative;
 }
 
 .tab__nav-item + .tab__nav-item{
@@ -1070,25 +1071,22 @@ body.is-drawer-active:after{
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 50px;
+    padding: 50px 30px;
     background-color: #fff;
 }
 
 .tab__contents-item {
     display: flex;
-    font-size: 18px;
+    font-size: 16px;
 }
 
 .tab__contents-link{
-    display: block;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    width: 326px;
+    overflow: hidden;
     color: #5e5e5e;
-    text-decoration-line: underline;
-    transition: text-decoration-line 0.8s ease-in-out;
-}
-
-.tab__contents-link:focus,.tab__contents-link:hover{
-    display:block;
-    text-decoration-line: none;
 }
 
 .tab__contents-icon {
@@ -1111,7 +1109,7 @@ body.is-drawer-active:after{
 
 .tab__contents-new {
     width: 35px;
-    margin: 2px 0 0 11px;
+    margin: 3px 0 0 11px;
 }
 
 /* -----------------------------------------------------------------
@@ -1425,25 +1423,38 @@ body.is-drawer-active:after{
     }
     
     .tab__contents-inner {
-        padding: 6vw;
+        padding: 6vw 3vw;
+    }
+
+    .tab__contents-list{
+        flex: 1;
     }
 
     .tab__contents-item {
-        font-size: 3vw;
+        font-size: 2.4vw;
+    }
+
+    .tab__contents-link{
+        width: 50vw;
     }
 
     .tab__contents-icon {
-        width: 4.2vw;
-        margin: 0.4vw 0 0 2vw;
+        width: 2.8vw;
+        margin: 0.4vw 0 0 1.2vw;
     }
 
     .tab__contents-info {
-        font-size: 3vw;
+        font-size: 2.4vw;
+        white-space: nowrap;
         margin-left: 0.8vw;
     }
 
-    .tab__img{
-        width: 28vw;
+    .tab__contents-new{
+        width: 6vw;
+    }
+
+    .tab__img-wrapper{
+        width: 27vw;
     }
 
     .form__title-link{

--- a/src/lesson34/js/contents/tab.js
+++ b/src/lesson34/js/contents/tab.js
@@ -2,10 +2,6 @@ import { format, differenceInCalendarDays } from "date-fns";
 import { createElementWithClassName } from "../modules/create-element";
 
 const url = "https://mocki.io/v1/759610d7-71f5-414a-982e-ac00ffd64206";
-// const url = "https://mocki.io/v1/8cc57c74-d671-48ac-b59f-d3dfb73ec8c1"; //No data
-// const url = "https://httpstat.us/503"; // 503 error
-// const url = "https://mocki.io/v1/fafafafa"; // Failed to fetch
-
 const tabNav = document.getElementById("js-tabNav");
 
 
@@ -116,32 +112,28 @@ const createTabContainer = () => {
     div.appendChild(tabNav.parentNode.replaceChild(div, tabNav));
 }
 
-const appendArticlesTitleFragment = (values) => {
+const createArticlesTitleFragment = values => {
     const fragment = document.createDocumentFragment();
-    const articleTitles = values.map(value => value.title);
-    const articleComments = values.map(value => value.comments);
-    const articleDate = values.map(value => value.date);
 
-      //記事タイトルの数だけliを追加
-    for (let i = 0; i < articleTitles.length; i++) {
+    values.forEach(value => {
         const li = createElementWithClassName("li", "tab__contents-item");
         const a = createElementWithClassName("a", "tab__contents-link link");
-        const numberOfComments = articleComments[i].length;
+        const numberOfComments = value.comments.length;
 
-        a.href = "#";
-        a.textContent = articleTitles[i];
+        a.href = `./article.html?id=${value.id}`;
+        a.textContent = value.title;
 
         fragment.appendChild(li).appendChild(a);
 
         //コメントがあれば件数とアイコンを表示
         if (numberOfComments > 0) {
-            const commentInfo = createCommentInfo(articleComments[i]);
+            const commentInfo = createCommentInfo(value.comments);
             li.appendChild(commentInfo);
         }
 
         //3日以内の投稿であればnewアイコンを表示
-        isNewArrival(articleDate[i]) && li.insertAdjacentElement("beforeend", createNewIcon());
-    }
+        isNewArrival(value.date) && li.insertAdjacentElement("beforeend", createNewIcon());
+    })
     return fragment;
 };
 
@@ -181,7 +173,7 @@ const createArticleContents = (data) => {
         //JSONデータでdisplayがtrueのカテゴリの場合はis-activeを付与
         data[i].display && tabContents.classList.add("is-active");
 
-        const articleTitlesFragment = appendArticlesTitleFragment(values[i]);
+        const articleTitlesFragment = createArticlesTitleFragment(values[i]);
         const contentsImgFragment = createImgFragments(data[i]);
 
         tabContainer.appendChild(tabContents).appendChild(tabContentsInner).appendChild(ul).appendChild(articleTitlesFragment);

--- a/src/lesson34/js/contents/tab.js
+++ b/src/lesson34/js/contents/tab.js
@@ -1,48 +1,64 @@
 import { format, differenceInCalendarDays } from "date-fns";
+import { createElementWithClassName } from "../modules/create-element";
+
+const url = "https://mocki.io/v1/759610d7-71f5-414a-982e-ac00ffd64206";
+// const url = "https://mocki.io/v1/8cc57c74-d671-48ac-b59f-d3dfb73ec8c1"; //No data
+// const url = "https://httpstat.us/503"; // 503 error
+// const url = "https://mocki.io/v1/fafafafa"; // Failed to fetch
+
 const tabNav = document.getElementById("js-tabNav");
 
-const createElementWithClassName = (type, className) => {
-    const element = document.createElement(type);
-    element.className = className;
-    return element;
+
+const addLoading = (target) => {
+    const img =createElementWithClassName('img', 'loading js-loading');
+    img.src = "/assets/img/loading-circle.gif";
+    target.appendChild(img);
+}
+
+const removeLoading = () => document.querySelector(".js-loading").remove();
+
+const displayInfo = (target, error) => {
+    const p = document.createElement("p");
+    p.textContent = error;
+    target.appendChild(p);
 };
 
-const fetchData = async(endpoint) => {
-    const response = await fetch(endpoint);
-    if (!response.ok) {
-        const errorMessage = `${response.status}:${response.statusText}`;
-        tabNav.appendChild(createErrorMessage(errorMessage));
-        console.error(errorMessage);
-        return;
-    }
-    return await response.json();
+const displayErrorStatus = (target, response) => {
+    const p = document.createElement("p");
+    p.textContent = `${response.status}:${response.statusText}`;
+    target.appendChild(p);
 };
 
-const fetchArrayData = async() => {
+const fetchData = async(api) => {
+    addLoading(tabNav);
     try {
-        const json = await fetchData("https://mocki.io/v1/43b10f2b-3404-49d0-865c-168aa49778fd");
-        // const json = await fetchData("https://mocki.io/v1/f12ae2d1-310d-4120-8749-47773d65e236");//空配列
-        // const json = await fetchData("https://httpstat.us/503");//503 error
-        
-        if (!json) return;
+        const response = await fetch(api);
 
-        const data = json.data;
-        if (data.length === 0) {
-            tabNav.textContent = "まだデータがありません";
-            console.log("まだデータがありません");
+        if (response.ok) {
+            return await response.json();
+        } else {
+            console.error(`${response.status}:${response.statusText}`);
+            displayErrorStatus(tabNav, response);
         }
-        return data;
-
-    } catch(e) {
-        console.error(e);
-        tabNav.appendChild(createErrorMessage(e));
+        
+    } catch (error) {
+        displayInfo(tabNav, error);
+    } finally {
+        removeLoading();
     }
 };
 
-const createErrorMessage = (text) => {
-    const errorText = createElementWithClassName("p", "tab__error");
-    errorText.textContent = text;
-    return errorText;
+const init = async() => {
+    const data = await fetchData(url);
+
+    if (!data) return;
+    if (!data.length) {
+        displayInfo(tabNav, "no data");
+    } else {
+        createTabNav(data);
+        createTabContainer();
+        createArticleContents(data);
+    }
 };
 
 const isNewArrival = (date) => {
@@ -109,7 +125,7 @@ const appendArticlesTitleFragment = (values) => {
       //記事タイトルの数だけliを追加
     for (let i = 0; i < articleTitles.length; i++) {
         const li = createElementWithClassName("li", "tab__contents-item");
-        const a = createElementWithClassName("a", "tab__contents-link");
+        const a = createElementWithClassName("a", "tab__contents-link link");
         const numberOfComments = articleComments[i].length;
 
         a.href = "#";
@@ -184,14 +200,4 @@ const createImgFragments = (data) => {
     return fragment;
 };
 
-const addTabContents = async() => {
-    const data = await fetchArrayData();
-
-    if(data){
-        createTabNav(data);
-        createArticleContents(data);
-    }
-};
-
-createTabContainer();
-addTabContents();
+init();


### PR DESCRIPTION
# [Issue No.34](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#34)
- ニュース詳細ページとお気に入り機能を作成する課題です


## 今回実装した仕様
課題34の仕様は満たしているのですが、Yahoo風のタブコンテンツのタイトルがダミーの状態だったので、改善ブランチとしてニュース一覧ページなどで使用しているものと同じ jsonデータから取得するように修正を行いました。

## 動作確認  [StackBlitz](https://stackblitz.com/edit/stackblitz-starters-7xwkju?file=src%2Flesson34%2Fjs%2Fcontents%2Ftab.js)
※お手数をおかけいたします。

1️⃣  会員登録→ログイン
2️⃣  yahoo風のタブコンテンツのタイトルが、ダミーではなく一覧ページのものと同様のことを確認
3️⃣ タイトルリンクをクリックすると、それぞれの記事詳細ページへ飛べることを確認


【旧ニュースタイトル】
![Screenshot by Dropbox Capture](https://github.com/haru-programming/JavaScript-lessons/assets/67426438/59ead11e-d9b4-454d-9718-8f6f089de33a)

【修正後のニュースタイトル】
![Screenshot by Dropbox Capture](https://github.com/haru-programming/JavaScript-lessons/assets/67426438/422872e2-3b43-4e74-a2e4-a01aa604f631)

※NEWアイコンは、Macの設定から時計を変更しないと表示されません。
例えば2022年3月8日にすると上記の表示になります。
手元で確認済みですので、今回は割愛していただければと思います。