### PR TITLE
Lesson35-1: Separate pages for non-logged-in users and for logged-in users

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -45,6 +45,7 @@
         <li><a href='/lesson32/index.html'>lesson32</a></li>
         <li><a href='/lesson33/index.html'>lesson33</a></li>
         <li><a href='/lesson34/index.html'>lesson34</a></li>
+        <li><a href='/lesson35/index.html'>lesson35</a></li>
       </ul>
     </main>
   </body>

--- a/src/lesson35/archive-news.html
+++ b/src/lesson35/archive-news.html
@@ -6,7 +6,7 @@
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <link rel="stylesheet" href="./css/reset.css" type="text/css">
         <link rel="stylesheet" href="./css/style.css" type="text/css">
-        <script>if (!localStorage.getItem("token")) window.location.href = "./login.html";</script>
+        <script>if (!localStorage.getItem("token")) window.location.href = "./";</script>
         <script type="module" src="./js/contents/main.js" defer></script>
         <script type="module" src="./js/archive-news.js"></script>
         <title>ニュース一覧</title>

--- a/src/lesson35/article.html
+++ b/src/lesson35/article.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link href="./css/reset.css" rel="stylesheet">
     <link href="./css/style.css" rel="stylesheet">
-    <script>if (!localStorage.getItem("token")) window.location.href = "./login.html";</script>
+    <script>if (!localStorage.getItem("token")) window.location.href = "./";</script>
     <script type="module" src="./js/article.js"></script>
     <title></title>
   </head>

--- a/src/lesson35/css/style.css
+++ b/src/lesson35/css/style.css
@@ -170,6 +170,28 @@ body.is-drawer-active:after{
     cursor: pointer;
 }
 
+.header__button-list{
+    display: flex;justify-content: center;align-items: center;
+    gap: 20px;
+}
+
+.header__button-anchor{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 160px;
+    height: 40px;
+    border: 1px solid #ccc;
+    border-radius: 30px;
+    text-decoration: none;
+    color: currentColor;
+    transition: background-color 0.3s ease-in-out;
+}
+
+.header__button-anchor:hover{
+    background-color: #EBEAEA;
+}
+
 .header__nav{
     position: fixed;
     z-index : 1200;
@@ -1044,7 +1066,7 @@ body.is-drawer-active:after{
     padding: 5px 7px;
     cursor: pointer;
     font-size: 16px;
-    background-color: #f8f8ff;
+    background-color: #eaebeb;
     border: 1px solid #ccc;
     border-radius: 3px 3px 0 0;
     transition: background-color 0.2s ease;
@@ -1215,6 +1237,18 @@ body.is-drawer-active:after{
     .header__button >img{
         width: 12vw;
     }
+
+    .header__button-list{
+      gap: 2vw;
+    }
+    
+    .header__button-anchor{
+      width: 20vw;
+      height: 6vw;
+      border-radius: 5vw;
+      font-size: 3vw;
+    }
+  
 
     .user-menu{
         top: 18vw;

--- a/src/lesson35/css/style.css
+++ b/src/lesson35/css/style.css
@@ -189,7 +189,7 @@ body.is-drawer-active:after{
 }
 
 .header__button-anchor:hover{
-    background-color: #EBEAEA;
+    background-color: #ebeaea;
 }
 
 .header__nav{

--- a/src/lesson35/index.html
+++ b/src/lesson35/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="./css/reset.css" type="text/css" />
   <link rel="stylesheet" href="./css/style.css" type="text/css" />
   <script type="module" src="./js/contents/tab.js"></script>
+  <script>if (localStorage.getItem("token")) window.location.href = "./logged-in.html";</script>
   <title>Haru news</title>
 </head>
 

--- a/src/lesson35/index.html
+++ b/src/lesson35/index.html
@@ -1,54 +1,31 @@
 <!DOCTYPE html>
 <html lang="ja">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta http-equiv="X-UA-Compatible" content="ie=edge">
-        <link rel="stylesheet" href="./css/reset.css" type="text/css">
-        <link rel="stylesheet" href="./css/style.css" type="text/css">
-        <script>if (!localStorage.getItem("token")) window.location.href = "./login.html";</script>
-        <script type="module" src="./js/contents/main.js"></script>
-        <script type="module" src="./js/contents/slideshow.js"></script>
-        <script type="module" src="./js/contents/tab.js"></script>
-        <title>Haru news</title>
-    </head>
-    <body>
-        <header class="header">
-            <div class="header__inner">
-                <h1 class="title top"><a href="./" class="header__link">haru news</a></h1>
-                <button class="header__button header__link" id="js-user-menu-button" type="button"><img src="/assets/img/img-user.png" alt="ユーザー管理画面" width="60" height="60" decoding="async"></button>
-            </div>
-            <div class="user-menu" id="js-user-menu" role="dialog">
-                <button class="user-menu__icon" id="js-close-icon" aria-label="Close">&times;</button>
-                <span class="user-menu__img"><img src="/assets/img/img-user.png" alt="ユーザー画像"></span>
-                <p class="user-menu__name" id="js-username"></p>
-                <p class="user-menu__email" id="js-email"></p>
-                <ul class="user-menu__list">
-                    <li class="user-menu__item"><a href="./mypage.html" class="link">マイページ</a></li>
-                    <li class="user-menu__item"><a href="./reset-email.html" class="link">メールアドレス変更</a></li>
-                    <li class="user-menu__item"><a href="./reset-password.html" class="link">パスワード変更</a></li>
-                </ul>
-                <button class="user-menu__button" id="js-logout-button" type="button">Logout</button>
-            </div>
-        </header>
-        <div class="slideshow">
-            <div class="slideshow__inner">
-                <button id="js-button-previous" class="slideshow__arrow js-button-arrow"><img src="/assets/img/icon-arrow-previous.svg" alt="戻る" width="512" height="512" decoding="async"></button>
-                <div id="js-pict" class="slideshow__pict">
-                    <ul id="js-pict-list" class="slideshow__pict-list"></ul>
-                </div>
-                <button id="js-button-next" class="slideshow__arrow js-button-arrow"><img src="/assets/img/icon-arrow-next.svg" alt="進む" width="512" height="512" decoding="async"></button>
-            </div>
-            <div id="js-pagination" class="pagination">
-                <ul id="js-pagination-list" class="pagination__list"></ul>
-                <p class="slideshow__counter"><span id="js-counter-current"></span>/<span id="js-counter-all" class="slideshow__counter-item"></span></p>
-            </div>
-        </div>
-        
-        <section class="inner">
-            <h2 class="title sub">＼ Today's News ／</h2>
-            <p class="inner__link"><a href="./archive-news.html" class="link">→ ニュース記事一覧へ移動</a></p>
-            <ul class="tab__nav-list" id="js-tabNav"></ul>
-        </section>
-    </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  <link rel="stylesheet" href="./css/reset.css" type="text/css" />
+  <link rel="stylesheet" href="./css/style.css" type="text/css" />
+  <script type="module" src="./js/contents/tab.js"></script>
+  <title>Haru news</title>
+</head>
+
+<body>
+  <header class="header">
+    <div class="header__inner">
+      <h1 class="title top"><a href="./" class="header__link">haru news</a></h1>
+      <ul class="header__button-list">
+        <li class="header__button-item"><a href="./login.html" class="header__button-anchor">Login</a></li>
+        <li class="header__button-item"><a href="./register.html" class="header__button-anchor">Register</a></li>
+      </ul>
+    </div>
+  </header>
+
+  <section class="inner" id="js-error-text">
+    <h2 class="title sub">＼ Loginしてね ／</h2>
+    <ul class="tab__nav-list" id="js-tabNav"></ul>
+  </section>
+</body>
+
 </html>

--- a/src/lesson35/js/login.js
+++ b/src/lesson35/js/login.js
@@ -13,8 +13,8 @@ formElements.forEach(element => {
     element.classList.add("invalid");
 
     element.addEventListener("blur", (e) => {
-        if (e.relatedTarget === eyeIcon) {
-            if (passwordOfInput.value && errorOfPassword.textContent === "入力してください") errorOfPassword.textContent = "";
+        if (e.relatedTarget === eyeIcon && passwordOfInput.value && errorOfPassword.textContent === "入力してください") {
+            errorOfPassword.textContent = "";
             return;
         }
 

--- a/src/lesson35/js/login.js
+++ b/src/lesson35/js/login.js
@@ -79,21 +79,22 @@ const checkToRegistered = async () => {
     if (user && user.password === passwordOfInput.value) {
         return { token: user.userId, ok: true, code: 200 };
     } else {
-        throw { ok: false, code: 401 };
+        throw new Error({ ok: false, code: 401 });
     }
 }
 
-const tryToLogin = async () => {
-
+const login = async () => {
+    let result;
     try {
-        const result = await checkToRegistered();
-        localStorage.setItem("token", result.token);
-        window.location.href = "./logged-in.html";
-    } catch (rejectObj) {
-        console.error('Login failed:', rejectObj);
+        result = await checkToRegistered();
+    } catch (error) {
+        console.error('Login failed:', error);
         window.location.href = "./notautherize.html";
+        return;
     }
+    localStorage.setItem("token", result.token);
+    window.location.href = "./logged-in.html";
 }
 
 
-submitButton.addEventListener("click", tryToLogin);
+submitButton.addEventListener("click", login);

--- a/src/lesson35/js/login.js
+++ b/src/lesson35/js/login.js
@@ -74,7 +74,6 @@ const fetchRegisteredData = async () => {
 
 const checkToRegistered = async () => {
     const registeredUsers = await fetchRegisteredData();
-    console.log(userIdOfInput, passwordOfInput);
     const user = registeredUsers.find(user => user.name === userIdOfInput.value || user.email === userIdOfInput.value);
 
     if (user && user.password === passwordOfInput.value) {

--- a/src/lesson35/js/login.js
+++ b/src/lesson35/js/login.js
@@ -5,7 +5,7 @@ const chance = new Chance();
 
 const userIdOfInput = document.querySelector(".js-form-userid");
 const passwordOfInput = document.querySelector(".js-form-password");
-const formElements = [userIdOfInput,passwordOfInput];
+const formElements = [userIdOfInput, passwordOfInput];
 const eyeIcon = document.querySelector(".js-eye-icon");
 const errorOfPassword = document.querySelector('[data-name="password-error"]');
 const submitButton = document.querySelector(".js-submit-button");
@@ -15,51 +15,89 @@ formElements.forEach(element => {
     element.classList.add("invalid");
 
     element.addEventListener("blur", (e) => {
-        if(e.relatedTarget === eyeIcon) {
-            if(passwordOfInput.value && errorOfPassword.textContent === "入力してください") errorOfPassword.textContent = "";
+        if (e.relatedTarget === eyeIcon) {
+            if (passwordOfInput.value && errorOfPassword.textContent === "入力してください") errorOfPassword.textContent = "";
             return;
         }
 
         checkFormValidityInBlur(submitButton, e.target);
-        confirmIfCanSubmit(submitButton,invalidItems);
+        confirmIfCanSubmit(submitButton, invalidItems);
     });
 });
 
 eyeIcon.addEventListener("click", togglePasswordDisplay);
 eyeIcon.addEventListener("blur", (e) => {
-    if(e.relatedTarget === passwordOfInput) return;
+    if (e.relatedTarget === passwordOfInput) return;
     checkFormValidityInBlur(submitButton, passwordOfInput);
 
-    if(invalidItems > 0) return;
-    confirmIfCanSubmit(submitButton,invalidItems);
+    if (invalidItems > 0) return;
+    confirmIfCanSubmit(submitButton, invalidItems);
 });
 
-const tryToLogin = async() => {
-    let result;
+const url = "https://652dc444f9afa8ef4b27cca3.mockapi.io/users";
+
+
+const displayInfo = (target, error) => {
+    const p = document.createElement("p");
+    p.textContent = error;
+    target.appendChild(p);
+};
+
+const displayErrorStatus = (target, response) => {
+    const p = document.createElement("p");
+    p.textContent = `${response.status}:${response.statusText}`;
+    target.appendChild(p);
+};
+
+const fetchData = async (api) => {
     try {
-        result = await checkToRegistered();
-        localStorage.setItem("token", result.token);
-    } catch(rejectObj) {
-        result = rejectObj;
-    } finally {
-        window.location.href = result.token ? "./index.html" : "./notautherize.html";
+        const response = await fetch(api);
+
+        if (response.ok) {
+            return await response.json();
+        } else {
+            console.error(`${response.status}:${response.statusText}`);
+            displayErrorStatus(errorArea, response);
+        }
+
+    } catch (error) {
+        displayInfo(errorArea, error);
+    }
+};
+
+const fetchRegisteredData = async () => {
+    const data = await fetchData(url);
+    if (!data) return;
+
+    if (data.length) {
+        return data;
+    }
+};
+
+const checkToRegistered = async (userIdInput, passwordInput) => {
+    const registeredUsers = await fetchRegisteredData();
+    const user = registeredUsers.find(user => user.name === userIdInput || user.email === userIdInput);
+
+    if (user && user.password === passwordInput) {
+        return { token: user.userId, ok: true, code: 200 };
+    } else {
+        throw { ok: false, code: 401 };
     }
 }
 
-const checkToRegistered = () => {
-    return new Promise((resolve, reject) => {
-        const inputsValues = {
-            userId: userIdOfInput.value,
-            password: passwordOfInput.value
-        }
-        const registeredData = JSON.parse(localStorage.getItem("registeredData"));
+const tryToLogin = async () => {
+    const userIdInput = document.getElementById('userId').value;
+    const passwordInput = document.getElementById('password').value;
 
-        if ((inputsValues.userId === registeredData.name || inputsValues.userId === registeredData.email) && (inputsValues.password === registeredData.password)) {
-            resolve({ token: chance.apple_token(), ok: true, code: 200 });
-        } else {
-            reject({ ok: false, code: 401 });
-        }
-    })
+    try {
+        const result = await checkToRegistered(userIdInput, passwordInput);
+        localStorage.setItem("token", result.token);
+        window.location.href = "./logged-in.html";
+    } catch (rejectObj) {
+        console.error('Login failed:', rejectObj);
+        window.location.href = "./notautherize.html";
+    }
 }
+
 
 submitButton.addEventListener("click", tryToLogin);

--- a/src/lesson35/js/login.js
+++ b/src/lesson35/js/login.js
@@ -1,7 +1,5 @@
 import { checkFormValidityInBlur, confirmIfCanSubmit } from "./modules/validation";
 import { togglePasswordDisplay } from "./modules/togglepassword";
-import { Chance } from "chance";
-const chance = new Chance();
 
 const userIdOfInput = document.querySelector(".js-form-userid");
 const passwordOfInput = document.querySelector(".js-form-password");
@@ -74,11 +72,11 @@ const fetchRegisteredData = async () => {
     }
 };
 
-const checkToRegistered = async (userIdInput, passwordInput) => {
+const checkToRegistered = async () => {
     const registeredUsers = await fetchRegisteredData();
-    const user = registeredUsers.find(user => user.name === userIdInput || user.email === userIdInput);
+    const user = registeredUsers.find(user => user.name === userIdOfInput || user.email === userIdOfInput);
 
-    if (user && user.password === passwordInput) {
+    if (user && user.password === passwordOfInput) {
         return { token: user.userId, ok: true, code: 200 };
     } else {
         throw { ok: false, code: 401 };
@@ -86,11 +84,8 @@ const checkToRegistered = async (userIdInput, passwordInput) => {
 }
 
 const tryToLogin = async () => {
-    const userIdInput = document.getElementById('userId').value;
-    const passwordInput = document.getElementById('password').value;
-
     try {
-        const result = await checkToRegistered(userIdInput, passwordInput);
+        const result = await checkToRegistered();
         localStorage.setItem("token", result.token);
         window.location.href = "./logged-in.html";
     } catch (rejectObj) {

--- a/src/lesson35/js/login.js
+++ b/src/lesson35/js/login.js
@@ -74,9 +74,10 @@ const fetchRegisteredData = async () => {
 
 const checkToRegistered = async () => {
     const registeredUsers = await fetchRegisteredData();
-    const user = registeredUsers.find(user => user.name === userIdOfInput || user.email === userIdOfInput);
+    console.log(userIdOfInput, passwordOfInput);
+    const user = registeredUsers.find(user => user.name === userIdOfInput.value || user.email === userIdOfInput.value);
 
-    if (user && user.password === passwordOfInput) {
+    if (user && user.password === passwordOfInput.value) {
         return { token: user.userId, ok: true, code: 200 };
     } else {
         throw { ok: false, code: 401 };
@@ -84,6 +85,7 @@ const checkToRegistered = async () => {
 }
 
 const tryToLogin = async () => {
+
     try {
         const result = await checkToRegistered();
         localStorage.setItem("token", result.token);

--- a/src/lesson35/logged-in.html
+++ b/src/lesson35/logged-in.html
@@ -10,6 +10,7 @@
   <script type="module" src="./js/contents/main.js"></script>
   <script type="module" src="./js/contents/slideshow.js"></script>
   <script type="module" src="./js/contents/tab.js"></script>
+  <script>if (!localStorage.getItem("token")) window.location.href = "./index.html";</script>
   <title>Haru news</title>
 </head>
 

--- a/src/lesson35/logged-in.html
+++ b/src/lesson35/logged-in.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="stylesheet" href="./css/reset.css" type="text/css">
+  <link rel="stylesheet" href="./css/style.css" type="text/css">
+  <script type="module" src="./js/contents/main.js"></script>
+  <script type="module" src="./js/contents/slideshow.js"></script>
+  <script type="module" src="./js/contents/tab.js"></script>
+  <title>Haru news</title>
+</head>
+
+<body>
+  <header class="header">
+    <div class="header__inner">
+      <h1 class="title top"><a href="./" class="header__link">haru news</a></h1>
+      <button class="header__button header__link" id="js-user-menu-button" type="button"><img src="/assets/img/img-user.png" alt="ユーザー管理画面" width="60" height="60" decoding="async"></button>
+    </div>
+    <div class="user-menu" id="js-user-menu" role="dialog">
+      <button class="user-menu__icon" id="js-close-icon" aria-label="Close">&times;</button>
+      <span class="user-menu__img"><img src="/assets/img/img-user.png" alt="ユーザー画像"></span>
+      <p class="user-menu__name" id="js-username"></p>
+      <p class="user-menu__email" id="js-email"></p>
+      <ul class="user-menu__list">
+        <li class="user-menu__item"><a href="./mypage.html" class="link">マイページ</a></li>
+        <li class="user-menu__item"><a href="./reset-email.html" class="link">メールアドレス変更</a></li>
+        <li class="user-menu__item"><a href="./reset-password.html" class="link">パスワード変更</a></li>
+      </ul>
+      <button class="user-menu__button" id="js-logout-button" type="button">Logout</button>
+    </div>
+  </header>
+  <div class="slideshow">
+    <div class="slideshow__inner">
+      <button id="js-button-previous" class="slideshow__arrow js-button-arrow"><img src="/assets/img/icon-arrow-previous.svg" alt="戻る" width="512" height="512" decoding="async"></button>
+      <div id="js-pict" class="slideshow__pict">
+        <ul id="js-pict-list" class="slideshow__pict-list"></ul>
+      </div>
+      <button id="js-button-next" class="slideshow__arrow js-button-arrow"><img src="/assets/img/icon-arrow-next.svg" alt="進む" width="512" height="512" decoding="async"></button>
+    </div>
+    <div id="js-pagination" class="pagination">
+      <ul id="js-pagination-list" class="pagination__list"></ul>
+      <p class="slideshow__counter"><span id="js-counter-current"></span>/<span id="js-counter-all" class="slideshow__counter-item"></span></p>
+    </div>
+  </div>
+
+  <section class="inner">
+    <h2 class="title sub">＼ Today's News ／</h2>
+    <p class="inner__link"><a href="./archive-news.html" class="link">→ ニュース記事一覧へ移動</a></p>
+    <ul class="tab__nav-list" id="js-tabNav"></ul>
+  </section>
+</body>
+
+</html>

--- a/src/lesson35/login.html
+++ b/src/lesson35/login.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" href="./css/reset.css">
         <link rel="stylesheet" href="./css/style.css">
         <script>
-            if (localStorage.getItem("token")) window.location.href = "./index.html";
+            if (localStorage.getItem("token")) window.location.href = "./logged-in.html";
         </script>
         <script type="module" src="./js/login.js"></script>
         <script type="module" src="./js/drawer-menu.js"></script>

--- a/src/lesson35/mypage.html
+++ b/src/lesson35/mypage.html
@@ -6,7 +6,7 @@
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <link rel="stylesheet" href="./css/reset.css" type="text/css">
         <link rel="stylesheet" href="./css/style.css" type="text/css">
-        <script>if (!localStorage.getItem("token")) window.location.href = "./login.html";</script>
+        <script>if (!localStorage.getItem("token")) window.location.href = "./";</script>
         <script type="module" src="./js/contents/main.js"></script>
         <script type="module" src="./js/mypage.js"></script>
         <title>マイページ</title>

--- a/src/lesson35/register-done.html
+++ b/src/lesson35/register-done.html
@@ -11,7 +11,7 @@
         <section class="form box">
             <h1 class="title">Your registration is complete.</h1>
             <p class="register__text" data-testid="complete-text">アカウント登録が完了しました。</p>
-            <p class="center form__anchor"><a href="./" class="link">ログインページへ移動する</a></p>
+            <p class="center form__anchor"><a href="./login.html" class="link">ログインページへ移動する</a></p>
         </section>
     </body>
 </html>

--- a/src/lesson35/reset-email.html
+++ b/src/lesson35/reset-email.html
@@ -6,7 +6,7 @@
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <link rel="stylesheet" href="./css/reset.css" type="text/css">
         <link rel="stylesheet" href="./css/style.css" type="text/css">
-        <script>if (!localStorage.getItem("token")) window.location.href = "./login.html";</script>
+        <script>if (!localStorage.getItem("token")) window.location.href = "./";</script>
         <script type="module" src="./js/reset-email.js"></script>
         <script type="module" src="./js/contents/main.js" defer></script>
         <title>メールアドレス変更ページ</title>

--- a/src/lesson35/reset-password.html
+++ b/src/lesson35/reset-password.html
@@ -6,7 +6,7 @@
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <link rel="stylesheet" href="./css/reset.css" type="text/css">
         <link rel="stylesheet" href="./css/style.css" type="text/css">
-        <script>if (!localStorage.getItem("token")) window.location.href = "./login.html";</script>
+        <script>if (!localStorage.getItem("token")) window.location.href = "./";</script>
         <script type="module" src="./js/reset-password.js"></script>
         <script type="module" src="./js/contents/main.js" defer></script>
         <title>パスワード変更ページ</title>

--- a/src/lesson35/users.json
+++ b/src/lesson35/users.json
@@ -1,0 +1,37 @@
+[
+    {
+        "name": "Hoeger",
+        "email": "Zella_Homenick38@example.net",
+        "password": "HQnmjPKBWkqzjeB",
+        "userId": "ae2efaa8fd0255cfafda76a7",
+        "id": "1"
+    },
+    {
+        "name": "Franecki",
+        "email": "Sadie77@example.org",
+        "password": "iO7gPh_qxzhpZpc",
+        "userId": "b1b97461ecd9480cebfbfee8",
+        "id": "2"
+    },
+    {
+        "name": "Collier",
+        "email": "Augustine18@example.net",
+        "password": "r1NNPFNlyJgTbd9",
+        "userId": "f0cb743cb6b5aa565fd707e5",
+        "id": "3"
+    },
+    {
+        "name": "Adams",
+        "email": "Granville83@example.org",
+        "password": "3W7j0bv11xf4odx",
+        "userId": "be29fa5ed5ca3ef7f2633b09",
+        "id": "4"
+    },
+    {
+        "name": "Rempel",
+        "email": "Kelsi_Feest@example.com",
+        "password": "zglN5n_jqdns2vj",
+        "userId": "ad98cd484df6fedc9961b637",
+        "id": "5"
+    }
+]


### PR DESCRIPTION
# [Issue No.35](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#35)

仕様変更（Discord "聞きたいことあります部屋" より）がありました。
変更点を取り入れて、ひと通り実装しました。

## 【旧仕様】
- ログイン済みのユーザーが見れるコンテンツとそうではないユーザーが見れるコンテンツです
- APIでユーザーに関するmeというエンドポイントのAPIを作り、 そこにはisAuthorizationのようなフィールドがあり、
- trueだったらログイン済みなページ ログイン済みなページでは課題のyahooページのコンテンツを表示して何かログイン済みユーザー特有のコンテンツに変更してください
- この場合ログインボタンの文言は「マイページ」となります
- falseなら 通常の作成済みのyahooを模したコンテンツが表示され ログインボタンが置いてあり、ページに遷移します

## 【変更点】
1️⃣ isAuthorizationは廃止。
2️⃣ ログインページでログイン時に「mockAPIのユーザー情報」と照合して、合っていればその情報の中にある"userId"をtokenとしてローカルストレージに保存する。
3️⃣ index.htmlは非ログインユーザーが見るページで、アクセス時にローカルストレージにtokenがあれば、ログインユーザー向けページ logged-in.htmlに遷移する

※会員登録ページの流れは変更なし。フォームに入力された情報は登録時にlocalStorgeに保存される。→ その情報でログインするという仕様がなくなる。mockAPIの情報と照合するように変更された。

## [StackBlitz](https://stackblitz.com/edit/stackblitz-starters-7xwkju?file=src%2Flesson35%2Fjs%2Flogin.js)<br>