### PR TITLE
 Lesson36-1: Display article data fetched from the API only the first time.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -46,6 +46,7 @@
         <li><a href='/lesson33/index.html'>lesson33</a></li>
         <li><a href='/lesson34/index.html'>lesson34</a></li>
         <li><a href='/lesson35/index.html'>lesson35</a></li>
+        <li><a href='/lesson36/index.html'>lesson36</a></li>
       </ul>
     </main>
   </body>

--- a/src/lesson36/css/style.css
+++ b/src/lesson36/css/style.css
@@ -1191,16 +1191,24 @@ body.is-drawer-active:after{
   max-width: 100%;
 }
 
-.article__text{
-  order: 4;
-  margin-top: 40px;
-}
-
 .article__link{
   order: 5;
   margin-top: 60px;
 }
 
+.article__list{
+  order: 4;
+  margin-top: 40px;
+}
+
+.article__item + .article__item {
+    margin-top: 40px;
+  }
+
+.article__author {
+  font-size: 20px;
+  font-weight: bold;
+}
 
 
 /* -----------------------------------------------------------------
@@ -1557,4 +1565,15 @@ body.is-drawer-active:after{
       font-size: max(5vw,20px);
     }
 
+    .article__item + .article__item {
+      margin-top: 6vw;
+    }
+
+    .article__author {
+      font-size: 4vw;
+    }
+    
+    .article__quote {
+      font-size: 3vw;
+    }
 }

--- a/src/lesson36/js/article.js
+++ b/src/lesson36/js/article.js
@@ -1,9 +1,7 @@
 import { createElementWithClassName } from "./modules/create-element";
 
-const url = "https://mocki.io/v1/759610d7-71f5-414a-982e-ac00ffd64206";
-// const url = "https://mocki.io/v1/8cc57c74-d671-48ac-b59f-d3dfb73ec8c1"; //No data
-// const url = "https://httpstat.us/503"; // 503 error
-// const url = "https://mocki.io/v1/fafafafa"; // Failed to fetch
+const articlesUrl = "https://mocki.io/v1/759610d7-71f5-414a-982e-ac00ffd64206";
+const contentsUrl = 'https://api.javascripttutorial.net/v1/quotes/?page=1&limit=10';
 
 const articleWrapper = document.getElementById("js-article");
 
@@ -47,8 +45,8 @@ const fetchData = async(api) => {
     }
 };
 
-const init = async() => {
-    const data = await fetchData(url);
+const initArticle = async() => {
+    const data = await fetchData(articlesUrl);
 
     if (!data) return;
     if (!data.length) {
@@ -56,6 +54,18 @@ const init = async() => {
     } else {
         renderArticle(data);
         addEventListenerForFavoriteButton(data);
+    }
+};
+
+const initContents = async() => {
+    const contentsData = await fetchData(contentsUrl);
+    const data = contentsData.data;
+
+    if (!data) return;
+    if (!data.length) {
+        displayInfo(articleWrapper, "no data");
+    } else {
+        renderContents(data);
     }
 };
 
@@ -115,12 +125,6 @@ const createArticleInfo = data => {
     date.textContent = `${data.date}`;
     articleInfo.appendChild(date);
     return articleInfo;
-}
-
-const createArticleContents = data => {
-    const articleContents = createElementWithClassName('p', 'article__text');
-    articleContents.textContent = `${data.content}`;
-    return articleContents;
 }
 
 const createThumbnail = data => {
@@ -189,7 +193,7 @@ const renderArticle = data => {
 
     setTitle(targetData);
     articleElement.appendChild(createArticleHead(targetData)).after(createArticleInfo(targetData));
-    articleElement.appendChild(createArticleContents(targetData)).after(createThumbnail(targetData));
+    articleElement.appendChild(createThumbnail(targetData));
     renderCategory(data);
 
     if(isRegisteredData()){
@@ -209,4 +213,23 @@ const addEventListenerForFavoriteButton = data => {
     })
 }
 
-init();
+const createContents = data => {
+  const fragment = document.createDocumentFragment();
+  const articleList = createElementWithClassName('ul', 'article__list');
+
+  data.forEach(article => {
+      const articleItem = createElementWithClassName('li', 'article__item');
+      const authorArea = createElementWithClassName('p', 'article__author');
+      const quoteArea = createElementWithClassName('p', 'article__quote');
+      authorArea.textContent = article.author;
+      quoteArea.textContent = article.quote;
+      fragment.appendChild(articleItem).appendChild(authorArea).after(quoteArea);
+  })
+  articleList.appendChild(fragment);
+  return articleList;
+}
+
+const renderContents = data => articleWrapper.appendChild(createContents(data));
+
+initArticle();
+initContents();


### PR DESCRIPTION
# [Issue No.36](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#36)
- yahoo風個別記事ページの記事を無限スクロール化

limit: 一つのfetchでどのくらいの文章を取得するか。初期値は10
page: 何ページ目か。初期値は1
currentPage: 現在のページ。カレントページに対して+1する値がパラメータとして渡すpageに代入されます

- スクロールする度にfetchされることを避けるために、fetchするための判断するif分が必要という認識です。スクロールが画面一番下より少し手前まできたか、等です
- このAPIを使って https://api.javascripttutorial.net/v1/quotes/?page=1&limit=10
パラメータ、スクロールで一番下まで言ったら、ローディングを出し、その間にapiにpageをプラス1して 取得します。 取得したら今ある他のDOMの最後に取得した記事を追加します

- そのapiのリクエストがすぐに返ってきてしまい、ローディングがすぐ終わってしまうので体験が得られないので ローディングを出してから0.5秒後にリクエストしてください

## 実装した仕様
・このAPIを使って https://api.javascripttutorial.net/v1/quotes/?page=1&limit=10 記事詳細ページに内容を表示させる。

## 動作確認(  [StackBlitz](https://stackblitz.com/edit/stackblitz-starters-7xwkju?file=src%2Flesson36%2Fjs%2Farticle.js) )
ログイン→yahoo風のニュースから詳細記事に飛ぶ→ コンテンツに以下のような記事が表示されているか確認

![Screenshot by Dropbox Capture](https://github.com/haru-programming/JavaScript-lessons/assets/67426438/d1410835-54af-4ff7-8537-0ec835f09296)

![Screenshot by Dropbox Capture](https://github.com/haru-programming/JavaScript-lessons/assets/67426438/ec67ef1f-0c05-4cfc-9f4b-6d9c871c974f)


## 注意
課題35の仕様が変更になり、ログイン方法が変わっております。
ログインの際は、下記のAPIデータのどれかを使用してログインしてください。
詳しい仕様変更については[こちら](https://github.com/haru-programming/JavaScript-lessons/pull/75)です。

``` js
[
   {
        "name": "Collier",
        "email": "Augustine18@example.net",
        "password": "r1NNPFNlyJgTbd9",
        "userId": "f0cb743cb6b5aa565fd707e5",
        "id": "3"
    },
    {
        "name": "Adams",
        "email": "Granville83@example.org",
        "password": "3W7j0bv11xf4odx",
        "userId": "be29fa5ed5ca3ef7f2633b09",
        "id": "4"
    }
]
```